### PR TITLE
[FE] 코어 - 공통 레이아웃 - 하단 네비게이션바 기능 추가 & 리팩토링

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -20,6 +20,13 @@ module.exports = {
   webpackFinal: async (config) => {
     config.resolve.alias["@public"] = path.resolve(__dirname, "../public/");
     config.resolve.alias["@src"] = path.resolve(__dirname, "../src/");
+    config.resolve.alias["@components"] = path.resolve(__dirname, "../src/components");
+    config.resolve.alias["@pages"] = path.resolve(__dirname, "../src/pages");
+    config.resolve.alias["@hooks"] = path.resolve(__dirname, "../src/hooks");
+    config.resolve.alias["@canvas"] = path.resolve(__dirname, "../src/canvas");
+    config.resolve.alias["@styles"] = path.resolve(__dirname, "../src/styles");
+    config.resolve.alias["@constants"] = path.resolve(__dirname, "../src/constants");
+    config.resolve.alias["@api"] = path.resolve(__dirname, "../src/api");
     return config;
   },
 };

--- a/client/src/components/BottomNavigationBar/index.tsx
+++ b/client/src/components/BottomNavigationBar/index.tsx
@@ -3,30 +3,29 @@ import homeIcon from "@public/icons/btn_home.svg";
 import staticsIcon from "@public/icons/btn_statics.svg";
 import searchIcon from "@public/icons/btn_search.svg";
 import profileIcon from "@public/icons/btn_profile.svg";
+import BottomNavigationButton from "@components/BottomNavigationButton";
 import * as s from "./style";
 
 const BottomNavigationBar = () => {
   return (
     <s.Wrapper>
       <s.Content>
-        <s.LinkButton to="/" className={({ isActive }) => (isActive ? "active" : "inactive")}>
-          <img src={homeIcon} alt="메인 화면 이동 아이콘" />
-        </s.LinkButton>
-        <s.LinkButton
-          to="/statics"
-          className={({ isActive }) => (isActive ? "active" : "inactive")}
-        >
-          <img src={staticsIcon} alt="통계 화면 이동 아이콘" />
-        </s.LinkButton>
-        <s.LinkButton to="/search" className={({ isActive }) => (isActive ? "active" : "inactive")}>
-          <img src={searchIcon} alt="검색 화면 이동 아이콘" />
-        </s.LinkButton>
-        <s.LinkButton
-          to="/profile"
-          className={({ isActive }) => (isActive ? "active" : "inactive")}
-        >
-          <img src={profileIcon} alt="프로필 화면 이동 아이콘" />
-        </s.LinkButton>
+        <BottomNavigationButton path="/" iconImageUrl={homeIcon} title="홈 화면 이동 아이콘" />
+        <BottomNavigationButton
+          path="/statics"
+          iconImageUrl={staticsIcon}
+          title="통계 화면 이동 아이콘"
+        />
+        <BottomNavigationButton
+          path="/search"
+          iconImageUrl={searchIcon}
+          title="검색 화면 이동 아이콘"
+        />
+        <BottomNavigationButton
+          path="/profile"
+          iconImageUrl={profileIcon}
+          title="프로필 화면 이동 아이콘"
+        />
       </s.Content>
     </s.Wrapper>
   );

--- a/client/src/components/BottomNavigationButton/index.tsx
+++ b/client/src/components/BottomNavigationButton/index.tsx
@@ -9,7 +9,11 @@ export interface BottomNavigationButtonProps {
 
 const BottomNavigationButton = ({ path, iconImageUrl, title }: BottomNavigationButtonProps) => {
   return (
-    <s.LinkButton to={path} className={({ isActive }) => (isActive ? "active" : "inactive")}>
+    <s.LinkButton
+      to={path}
+      className={({ isActive }) => (isActive ? "active" : "inactive")}
+      replace
+    >
       <img src={iconImageUrl} alt={title} />
     </s.LinkButton>
   );

--- a/client/src/components/BottomNavigationButton/index.tsx
+++ b/client/src/components/BottomNavigationButton/index.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import * as s from "./style";
+
+export interface BottomNavigationButtonProps {
+  path: string;
+  iconImageUrl: string;
+  title: string;
+}
+
+const BottomNavigationButton = ({ path, iconImageUrl, title }: BottomNavigationButtonProps) => {
+  return (
+    <s.LinkButton to={path} className={({ isActive }) => (isActive ? "active" : "inactive")}>
+      <img src={iconImageUrl} alt={title} />
+    </s.LinkButton>
+  );
+};
+
+export default BottomNavigationButton;

--- a/client/src/components/BottomNavigationButton/style.ts
+++ b/client/src/components/BottomNavigationButton/style.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+import { NavLink } from "react-router-dom";
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 60px;
+  display: flex;
+  justify-content: center;
+  background-color: ${({ theme }) => theme.COLORS.WHITE};
+`;
+
+export const LinkButton = styled(NavLink)`
+  text-align: center;
+  width: 25%;
+
+  background-color: transparent;
+  border: none;
+  filter: ${({ theme }) => theme.COLORS.FILTER_GRAY};
+
+  &.active {
+    filter: ${({ theme }) => theme.COLORS.FILTER_BLUE};
+  }
+`;


### PR DESCRIPTION
## 작업내용
1. storybook에서 사용하는 & 사용할 것으로 예상되는 경로를 위한 Path alias 모두 설정해뒀습니다.
2. 네비게이션바의 버튼을 별도의 컴포넌트로 분리하였습니다.
3. 기존에 페이지를 이동하고 뒤로가기 버튼을 누르면, 이전의 화면으로 가졌으나,
history replace처리를 통해 depth가 0이라면 나가지게 설정해뒀습니다.

## 세부 작업내용
```
const BottomNavigationButton = ({ path, iconImageUrl, title }: BottomNavigationButtonProps) => {
  return (
    <s.LinkButton
      to={path}
      className={({ isActive }) => (isActive ? "active" : "inactive")}
      replace
    >
      <img src={iconImageUrl} alt={title} />
    </s.LinkButton>
  );
};
```

`<BottomNavigationButton path="/" iconImageUrl={homeIcon} title="홈 화면 이동 아이콘" />`

```
config.resolve.alias["@pages"] = path.resolve(__dirname, "../src/pages");
config.resolve.alias["@hooks"] = path.resolve(__dirname, "../src/hooks");
config.resolve.alias["@canvas"] = path.resolve(__dirname, "../src/canvas");
config.resolve.alias["@styles"] = path.resolve(__dirname, "../src/styles");
config.resolve.alias["@constants"] = path.resolve(__dirname, "../src/constants");
config.resolve.alias["@api"] = path.resolve(__dirname, "../src/api");
```

