### PR TITLE
[BE] API 구현 - Google Login API 구현, Google Login 정보 DB에 저장

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,10 +1,33 @@
 import { Module } from "@nestjs/common";
-import { AppController } from "./app.controller";
-import { AppService } from "./app.service";
+import { APP_FILTER } from "@nestjs/core";
+import { PassportModule } from "@nestjs/passport";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import * as dotenv from "dotenv";
+import { HttpExceptionFilter } from "./exception/HttpExceptionFilter";
+import { GoogleOauthModule } from "./oauth/google-oauth/google-oauth.module";
+import { UserModule } from "./user/user.module";
+import { User } from "./typeorm/entities/User";
+import { MYSQL_DB, MYSQL_HOST, MYSQL_PASSWORD, MYSQL_USER } from "./utils/env";
+
+dotenv.config();
 
 @Module({
-  imports: [],
-  controllers: [AppController],
-  providers: [AppService],
+  imports: [
+    GoogleOauthModule,
+    UserModule,
+    TypeOrmModule.forRoot({
+      type: "mysql",
+      host: MYSQL_HOST,
+      port: 3306,
+      username: MYSQL_USER,
+      password: MYSQL_PASSWORD,
+      database: MYSQL_DB,
+      entities: [User],
+      synchronize: true,
+    }),
+    PassportModule.register({ session: true }),
+  ],
+
+  providers: [{ provide: APP_FILTER, useClass: HttpExceptionFilter }],
 })
 export class AppModule {}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,8 +1,27 @@
 import { NestFactory } from "@nestjs/core";
+import session from "express-session";
+import passport from "passport";
 import { AppModule } from "./app.module";
+import { HttpExceptionFilter } from "./exception/HttpExceptionFilter";
+import { PORT } from "./utils/env";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  app.useGlobalFilters(new HttpExceptionFilter()); // 전역 필터 적용
+
+  app.use(
+    session({
+      secret: process.env.ACCESS_TOKEN_SECRETKEY as string,
+      saveUninitialized: false,
+      resave: false,
+      cookie: {
+        maxAge: 60000,
+      },
+    }),
+  );
+  app.use(passport.initialize());
+  app.use(passport.session());
+
+  await app.listen(PORT as string);
 }
 bootstrap();

--- a/server/src/oauth/google-oauth/dto/create-google-oauth.dto.ts
+++ b/server/src/oauth/google-oauth/dto/create-google-oauth.dto.ts
@@ -1,0 +1,1 @@
+export class CreateGoogleOauthDto {}

--- a/server/src/oauth/google-oauth/dto/update-google-oauth.dto.ts
+++ b/server/src/oauth/google-oauth/dto/update-google-oauth.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateGoogleOauthDto } from './create-google-oauth.dto';
+
+export class UpdateGoogleOauthDto extends PartialType(CreateGoogleOauthDto) {}

--- a/server/src/oauth/google-oauth/google-oauth.controller.spec.ts
+++ b/server/src/oauth/google-oauth/google-oauth.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { GoogleOauthController } from "./google-oauth.controller";
+import { GoogleOauthService } from "./google-oauth.service";
+
+describe("GoogleOauthController", () => {
+  let controller: GoogleOauthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GoogleOauthController],
+      providers: [GoogleOauthService],
+    }).compile();
+
+    controller = module.get<GoogleOauthController>(GoogleOauthController);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/oauth/google-oauth/google-oauth.controller.ts
+++ b/server/src/oauth/google-oauth/google-oauth.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Inject, Req, UseGuards } from "@nestjs/common";
+import { GoogleOauthService } from "./google-oauth.service";
+import { GoogleOAuthGuard } from "./utils/google.guards";
+import { RequestType } from "../../types/request.type";
+
+@Controller("api/oauth/google")
+export class GoogleOauthController {
+  constructor(@Inject("AUTH_SERVICE") private readonly googleOauthService: GoogleOauthService) {}
+
+  @Get()
+  @UseGuards(GoogleOAuthGuard)
+  googleOAuth() {
+    // redirect google login page
+    return { msg: "Google Authentication" };
+  }
+
+  @Get("callback")
+  @UseGuards(GoogleOAuthGuard)
+  googleOAuthCallback(@Req() request: RequestType) {
+    return this.googleOauthService.googleLogin(request);
+  }
+
+  @Get("status")
+  user(@Req() request: RequestType) {
+    console.log(request.user);
+    if (request.user) {
+      return { msg: "Authenticated" };
+    }
+    return { msg: "Not Authenticated" };
+  }
+}

--- a/server/src/oauth/google-oauth/google-oauth.module.ts
+++ b/server/src/oauth/google-oauth/google-oauth.module.ts
@@ -1,0 +1,21 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { GoogleOauthController } from "./google-oauth.controller";
+import { GoogleStrategy } from "./utils/google.strategy";
+import { GoogleOauthService } from "./google-oauth.service";
+import { SessionSerializer } from "./utils/google.serializer";
+import { User } from "../../typeorm/entities/User";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  controllers: [GoogleOauthController],
+  providers: [
+    GoogleStrategy,
+    SessionSerializer,
+    {
+      provide: "AUTH_SERVICE",
+      useClass: GoogleOauthService,
+    },
+  ],
+})
+export class GoogleOauthModule {}

--- a/server/src/oauth/google-oauth/google-oauth.service.spec.ts
+++ b/server/src/oauth/google-oauth/google-oauth.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GoogleOauthService } from './google-oauth.service';
+
+describe('GoogleOauthService', () => {
+  let service: GoogleOauthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GoogleOauthService],
+    }).compile();
+
+    service = module.get<GoogleOauthService>(GoogleOauthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/oauth/google-oauth/google-oauth.service.ts
+++ b/server/src/oauth/google-oauth/google-oauth.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { User } from "../../typeorm/entities/User";
+import { GoogleUserInfoType } from "../../types/user.type";
+import { RequestType } from "../../types/request.type";
+
+@Injectable()
+export class GoogleOauthService {
+  constructor(@InjectRepository(User) private readonly userRepository: Repository<User>) {}
+
+  async validateUser(googleUserInfo: GoogleUserInfoType) {
+    console.log("GoogleOauthService");
+    console.log(googleUserInfo);
+    const user = await this.userRepository.findOneBy({ email: googleUserInfo.email });
+    console.log(user);
+    if (user) return user;
+    console.log("User not found. Creating...");
+    const newUser = this.userRepository.create(googleUserInfo);
+    return this.userRepository.save(newUser);
+  }
+
+  async findUser(id: number) {
+    const user = await this.userRepository.findOneBy({ id });
+    return user;
+  }
+
+  googleLogin(request: RequestType) {
+    if (!request.user) {
+      return "No user from google";
+    }
+
+    return {
+      message: "User information from google",
+      user: request.user,
+    };
+  }
+}

--- a/server/src/oauth/google-oauth/utils/google.guards.ts
+++ b/server/src/oauth/google-oauth/utils/google.guards.ts
@@ -1,0 +1,14 @@
+import { ExecutionContext, Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+@Injectable()
+export class GoogleOAuthGuard extends AuthGuard("google") {
+  async canActivate(context: ExecutionContext) {
+    const activate = (await super.canActivate(context)) as boolean;
+    const request = context.switchToHttp().getRequest();
+
+    await super.logIn(request);
+
+    return activate;
+  }
+}

--- a/server/src/oauth/google-oauth/utils/google.serializer.ts
+++ b/server/src/oauth/google-oauth/utils/google.serializer.ts
@@ -1,0 +1,24 @@
+/* eslint-disable-next-line @typescript-eslint/ban-types */
+import { Inject, Injectable } from "@nestjs/common";
+import { PassportSerializer } from "@nestjs/passport";
+import { GoogleOauthService } from "../google-oauth.service";
+import { User } from "../../../typeorm/entities/User";
+
+@Injectable()
+export class SessionSerializer extends PassportSerializer {
+  constructor(@Inject("AUTH_SERVICE") private readonly googleOauthService: GoogleOauthService) {
+    super();
+  }
+
+  serializeUser(user: User, done: Function) {
+    console.log("Serializer User");
+    done(null, user);
+  }
+
+  async deserializeUser(payload: any, done: Function) {
+    const user = await this.googleOauthService.findUser(payload.id);
+    console.log("Deserialize User");
+    console.log(user);
+    return user ? done(null, user) : done(null, null);
+  }
+}

--- a/server/src/oauth/google-oauth/utils/google.strategy.ts
+++ b/server/src/oauth/google-oauth/utils/google.strategy.ts
@@ -1,0 +1,31 @@
+import { PassportStrategy } from "@nestjs/passport";
+import { Strategy } from "passport-google-oauth20";
+import { Inject, Injectable } from "@nestjs/common";
+import { Profile } from "passport";
+import { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT } from "../../../utils/env";
+import { GoogleOauthService } from "../google-oauth.service";
+
+@Injectable()
+export class GoogleStrategy extends PassportStrategy(Strategy) {
+  constructor(@Inject("AUTH_SERVICE") private readonly googleOauthService: GoogleOauthService) {
+    super({
+      clientID: GOOGLE_CLIENT_ID,
+      clientSecret: GOOGLE_CLIENT_SECRET,
+      callbackURL: GOOGLE_REDIRECT,
+      scope: ["profile", "email"],
+    });
+  }
+
+  async validate(accessToken: string, refreshToken: string, profile: Profile) {
+    const user = await this.googleOauthService.validateUser({
+      name: profile.displayName,
+      email: profile.emails[0].value, // 엄격한 null 검사 사용 해제
+      profileImage: profile.photos[0].value,
+      accessToken: accessToken || "NO accessToken",
+      refreshToken: refreshToken || "NO refreshToken",
+    });
+    console.log("Validate");
+    console.log(user);
+    return user || null;
+  }
+}

--- a/server/src/typeorm/entities/User.ts
+++ b/server/src/typeorm/entities/User.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity({ name: "users" })
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  email: string;
+
+  @Column()
+  profileImage: string;
+
+  @Column()
+  accessToken: string;
+
+  @Column()
+  refreshToken: string;
+}

--- a/server/src/types/request.type.ts
+++ b/server/src/types/request.type.ts
@@ -1,0 +1,5 @@
+import { Request } from "express";
+
+export interface RequestType extends Request {
+  user: string;
+}

--- a/server/src/types/user.type.ts
+++ b/server/src/types/user.type.ts
@@ -1,0 +1,18 @@
+export type UserType = {
+  profileImage: string;
+  name: string;
+  age: number;
+  gender: number;
+  height: number;
+  weight: number;
+  introduce: string;
+  challengeTimestamp: string;
+};
+
+export type GoogleUserInfoType = {
+  name: string;
+  email: string;
+  profileImage: string;
+  accessToken: string;
+  refreshToken: string;
+};


### PR DESCRIPTION
### 관련 이슈

[Class constructor MixinStrategy cannot be invoked without 'new'](https://github.com/nestjs/nest/issues/2190)

[OAuth 2.0 Playground "Something bad happened: 500 HTTP error"](https://stackoverflow.com/questions/61250537/oauth-2-0-playground-something-bad-happened-500-http-error)

[Typescript Error: Property 'user' does not exist on type 'Request'](https://stackoverflow.com/questions/44383387/typescript-error-property-user-does-not-exist-on-type-request)

[Nest can't resolve dependencies of the Service (?). Please make sure that the argument Repository at index [0] is available in the ResultIoModule](https://junior-datalist.tistory.com/147)

### 작업 사항
- [x] api end point 설정
- [x] callback 설정
- [x] DB에 사용자 정보 저장
- [x] access 토큰 발행
- [x] 사용자 정보 get
  - [x] 이름
  - [x] 이메일
  - [x] 프로필 사진
- [x] `User` table 생성
- [x] local DB 연결
- [x] `User` table에 로그인 정보 입력

### 작업 요약
> Google Login API 구현
> Google Login 정보 DB에 저장

### 첨부
<img width="1718" alt="스크린샷 2022-11-18 오전 12 31 10" src="https://user-images.githubusercontent.com/70889358/202494688-15055a7c-d610-4de5-9e57-8cee02a7f31f.png">

![image](https://user-images.githubusercontent.com/70889358/202494836-7b9b52bc-4d18-48bb-af66-f3b43468df07.png)


### 참고자료
> [How to Implement Login with Google in Nest JS](https://dev.to/imichaelowolabi/how-to-implement-login-with-google-in-nest-js-2aoa)
> [Nest.js에서 Goolge Oauth 적용하기](https://velog.io/@sinf/Nest.js%EC%97%90%EC%84%9C-Goolge-Oauth-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)
> [NestJS & Google OAuth2 with Passport](https://www.youtube.com/watch?v=OitgkKTxht4)