### PR TITLE
[FE] 홈 페이지 - 메인 - 프로필 이미지 컨테이너 리팩토링

### DIFF
--- a/client/src/components/ProfileImageContainer/index.tsx
+++ b/client/src/components/ProfileImageContainer/index.tsx
@@ -16,14 +16,16 @@ const ProfileImageContainer = ({ isModified }: { isModified: boolean }) => {
   };
   return (
     <s.Wrapper>
-      <s.ImageContainer src={image} />
-      <s.ImageContainer
-        src={editableProfileImage}
-        hidden={isModified}
-        onClick={() => {
-          imgRef.current?.click();
-        }}
-      />
+      <s.ContainerBox>
+        <s.editImageContainer src={image} />
+        <s.ImageContainer
+          src={editableProfileImage}
+          hidden={isModified}
+          onClick={() => {
+            imgRef.current?.click();
+          }}
+        />
+      </s.ContainerBox>
       <input
         disabled={isModified}
         type="file"

--- a/client/src/components/ProfileImageContainer/style.ts
+++ b/client/src/components/ProfileImageContainer/style.ts
@@ -2,19 +2,22 @@ import styled from "styled-components";
 
 export const Wrapper = styled.div`
   width: 100%;
-  height: 100%;
 `;
 
 export const ImageContainer = styled.img`
   width: 100%;
-
   border-radius: 50%;
   position: absolute;
   left: 0;
   top: 0;
 `;
 
-export const ContainerBox = styled.div`
+export const editImageContainer = styled.img`
   width: 100%;
+`;
+
+export const ContainerBox = styled.div`
   position: relative;
+  border-radius: 50%;
+  width: 100%;
 `;

--- a/client/src/stories/BottomNavigationBar.stories.tsx
+++ b/client/src/stories/BottomNavigationBar.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: "components/BottomNavigationBar",
   component: BottomNavigationBar,
   decorators: [
-    (Story) => (
+    (Story: any) => (
       <MemoryRouter>
         <Story />
       </MemoryRouter>

--- a/client/src/stories/Calendar.stories.tsx
+++ b/client/src/stories/Calendar.stories.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Meta } from "@storybook/react";
+import Calendar from "@components/Calendar";
+
+export default {
+  title: "components/Calendar",
+  component: Calendar,
+} as Meta;
+
+export const DefaultCalendar = () => <Calendar />;


### PR DESCRIPTION
### 관련 이슈
#52

### 작업 사항
- [x] 부모 div의 크기에 따라 크기 조절하게 변경

### 작업 요약
- 프로필의 크기 조절이 안되던 문제를 해결하였습니다.
- 컨테이너를 감싸는 부모 div의 크기에 따라 변경됩니다.


### 참고자료
[css 이미지 겹치기](https://bebeya.tistory.com/entry/css-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EA%B2%B9%EC%B9%98%EA%B8%B0-2%EA%B0%9C-3%EA%B0%9C-position-absolute-relative)