### PR TITLE
[BE] API 구현 - Alarm API 구현 (공통) - Fetch Unread Alram API 구현 

### DIFF
--- a/server/src/alarms/alarms.controller.ts
+++ b/server/src/alarms/alarms.controller.ts
@@ -1,4 +1,21 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Query } from "@nestjs/common";
+import { ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { AlarmsService } from "./alarms.service";
 
-@Controller('alarms')
-export class AlarmsController {}
+@Controller("alarms")
+@ApiTags("ALARM API")
+export class AlarmsController {
+  constructor(private readonly alarmService: AlarmsService) {}
+
+  @Get("everyDate")
+  @ApiOperation({
+    summary: "해당 사용자가 읽지 않은 알림 수를 반환",
+  })
+  @ApiQuery({
+    name: "userId",
+    type: "number",
+  })
+  getUnreadAlarmCount(@Query("userId") userId: number) {
+    return this.alarmService.countUnreadAlarm(userId);
+  }
+}

--- a/server/src/alarms/alarms.service.ts
+++ b/server/src/alarms/alarms.service.ts
@@ -1,4 +1,19 @@
-import { Injectable } from '@nestjs/common';
+import { Alarm } from "./entities/alram.entity";
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
 
 @Injectable()
-export class AlarmsService {}
+export class AlarmsService {
+  constructor(
+    @InjectRepository(Alarm)
+    private alarmRepository: Repository<Alarm>,
+  ) {}
+
+  async countUnreadAlarm(userId: number) {
+    const alarmCount = await this.alarmRepository.count({
+      where: [{ receiverUserId: userId }, { check: true }],
+    });
+    return { alarmCount };
+  }
+}

--- a/server/src/alarms/alarms.service.ts
+++ b/server/src/alarms/alarms.service.ts
@@ -11,9 +11,10 @@ export class AlarmsService {
   ) {}
 
   async countUnreadAlarm(userId: number) {
-    const alarmCount = await this.alarmRepository.count({
-      where: [{ receiverUserId: userId }, { check: true }],
-    });
+    const alarmCount = await this.alarmRepository
+      .createQueryBuilder("alarm")
+      .where("alarm.receiver_user_id = :userId", { userId })
+      .getCount();
     return { alarmCount };
   }
 }

--- a/server/src/alarms/entities/alram.entity.ts
+++ b/server/src/alarms/entities/alram.entity.ts
@@ -20,9 +20,4 @@ export class Alarm {
 
   @Column({ name: "check" })
   check!: boolean;
-
-  // FK
-  // @ManyToOne(() => User)
-  // @JoinColumn({ name: "user_id" })
-  // user!: User;
 }

--- a/server/src/alarms/entities/alram.entity.ts
+++ b/server/src/alarms/entities/alram.entity.ts
@@ -6,6 +6,9 @@ export class Alarm {
   @PrimaryGeneratedColumn()
   id!: number;
 
+  @Column({ name: "receiver_user_id" })
+  receiverUserId!: number;
+
   @Column({ name: "sender_user_id" })
   senderUserId!: number;
 
@@ -19,7 +22,7 @@ export class Alarm {
   check!: boolean;
 
   // FK
-  @ManyToOne(() => User)
-  @JoinColumn({ name: "user_id" })
-  user!: User;
+  // @ManyToOne(() => User)
+  // @JoinColumn({ name: "user_id" })
+  // user!: User;
 }

--- a/server/src/users/entities/user.entity.ts
+++ b/server/src/users/entities/user.entity.ts
@@ -5,51 +5,51 @@ export class User {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column({ length: 45 })
+  @Column({ nullable: true, length: 45 })
   name!: string;
 
-  @Column()
+  @Column({ nullable: true })
   age!: number;
 
-  @Column()
+  @Column({ nullable: true })
   gender!: number;
 
-  @Column()
+  @Column({ nullable: true })
   height!: number;
 
-  @Column()
+  @Column({ nullable: true })
   weight!: number;
 
-  @Column({ length: 180 })
+  @Column({ nullable: true, length: 180 })
   introduce!: string;
 
   // TODO: 이미지 컬럼은 일단 보류
   // @Column({ name: "", length: 0 })
   // profileImage!: string;
 
-  @Column()
+  @Column({ nullable: true })
   tier!: number;
 
-  @Column({ name: "follower_count" })
+  @Column({ nullable: true, name: "follower_count" })
   followerCount!: number;
 
-  @Column({ name: "following_count" })
+  @Column({ nullable: true, name: "following_count" })
   followingCount!: number;
 
-  @Column({ name: "volume_sum" })
+  @Column({ nullable: true, name: "volume_sum" })
   volumeSum!: number;
 
   //! temp
 
-  @Column({ length: 180 })
+  @Column({ nullable: true, length: 180 })
   email!: string;
 
-  @Column({ length: 180 })
+  @Column({ nullable: true, length: 180 })
   profileImage!: string;
 
-  @Column({ length: 180 })
+  @Column({ nullable: true, length: 180 })
   accessToken!: string;
 
-  @Column({ length: 180 })
+  @Column({ nullable: true, length: 180 })
   refreshToken!: string;
 }


### PR DESCRIPTION
### 관련 이슈
기존 테이블 관계로 COUNT를 실행했지만, JOIN 이슈로 인해 데이터 1,000개 받아오는데에 30초 정도 걸림

생각해보니 alarm 테이블에서의 외래키의 필요성을 느끼지 못해 관계를 끊음

### 작업 사항
- [x] 외래키 이슈로 인해 외래키 관계 제거
- [x] swagger로 응답 확인

### 작업 요약
> 사용자의 Id를 요청하면 해당 사용자가 읽지 않은 alarm의 수를 응답하는 API
> JOIN의 심각한 성능 저하로 인해 FK 관계 제거함

### 첨부
![image](https://user-images.githubusercontent.com/79911816/203110428-1a8b7fbe-d144-4995-b763-7c00bb03a592.png)


### 참고자료
[typeORM에서 COUNT 쓰기](https://github.com/typeorm/typeorm/issues/673)
