### PR TITLE
[BE] API 구현 - Exercise API - Exercise API 수정

### DIFF
--- a/server/src/config/typeorm.config.ts
+++ b/server/src/config/typeorm.config.ts
@@ -16,6 +16,6 @@ export const typeormConfig: TypeOrmModuleOptions = {
   password: DB_PWD,
   database: DB_NAME,
   entities: [User, Routine, Exercise, Alarm, SBD_record, SBD_statistics, Follow],
-  synchronize: true,
+  synchronize: false,
   logging: true,
 };

--- a/server/src/exercises/exercises.controller.ts
+++ b/server/src/exercises/exercises.controller.ts
@@ -34,4 +34,16 @@ export class ExercisesController {
   getExerciseHistoryOfMonth(@Query("month") month: number, @Query("userId") userId: number) {
     return this.exercisesService.findExerciseHistoryOfMonth(month, userId);
   }
+
+  @Get("profile")
+  @ApiOperation({
+    summary: "홈 페이지의 프로필에 필요한, 해당 사용자의 총 볼륨, 운동 일수를 반환",
+  })
+  @ApiQuery({
+    name: "userId",
+    type: "number",
+  })
+  getInfoForProfile(@Query("userId") userId: number) {
+    return this.exercisesService.getProfileData(userId);
+  }
 }

--- a/server/src/exercises/exercises.service.ts
+++ b/server/src/exercises/exercises.service.ts
@@ -26,4 +26,34 @@ export class ExercisesService {
     });
     return new HistoryOfMonthDto(exerciseHistory);
   }
+
+  async getTotalVolume(userId: number) {
+    const exerciseList = await this.exerciseRepository
+      .createQueryBuilder("exercise")
+      .select("exercise.exerciseString")
+      .where("exercise.user_id = :userId", { userId })
+      .getMany();
+    let totalVolume: number = 0;
+    exerciseList.map((element) => {
+      element.exerciseString.split("|").map((item) => {
+        const [kg, _, check] = item.split("/");
+        totalVolume += Number(check) * Number(kg);
+      });
+    });
+    return totalVolume;
+  }
+
+  async getTotalExerciseDate(userId: number) {
+    return await this.exerciseRepository
+      .createQueryBuilder("exercise")
+      .select("exercise.date")
+      .where("exercise.user_id = :userId", { userId })
+      .getCount();
+  }
+
+  async getProfileData(userId: number) {
+    const totalVolume = await this.getTotalVolume(userId);
+    const totalExerciseDate = await this.getTotalExerciseDate(userId);
+    return { totalVolume, totalExerciseDate };
+  }
 }


### PR DESCRIPTION
### 관련 이슈
홈 페이지의 사용자 프로필에 어떤 정보를 넣을지 결정이 되었으므로, 

예전에 구현해 둔 API의 응답 항목을 다음과 같이 반환하도록 수정함

<img width="490" alt="스크린샷 2022-11-22 오후 3 12 15" src="https://user-images.githubusercontent.com/79911816/203238461-825c072b-7145-415c-b514-7657e4c6e808.png">


### 작업 사항
- [x] Exercise API 수정
- [x] swagger로 응답 확인

### 작업 요약
Exercise API를 홈 페이지의 프로필 란에 필요한 정보를 응답하도록 수정

