### PR TITLE
[BE] API 구현 - 모든 API를 TypeORM - query builder 문법으로 수정

### DIFF
--- a/server/src/config/typeorm.config.ts
+++ b/server/src/config/typeorm.config.ts
@@ -16,6 +16,6 @@ export const typeormConfig: TypeOrmModuleOptions = {
   password: DB_PWD,
   database: DB_NAME,
   entities: [User, Routine, Exercise, Alarm, SBD_record, SBD_statistics, Follow],
-  synchronize: true,
+  synchronize: false,
   logging: true,
 };

--- a/server/src/exercises/dto/every-date.dto.ts
+++ b/server/src/exercises/dto/every-date.dto.ts
@@ -5,8 +5,5 @@ export class EveryDateDto {
     dateObject.map((item) => {
       this.dateList.push(item.date);
     });
-    this.dateList.sort((a, b) => {
-      return Number(a) - Number(b);
-    });
   }
 }

--- a/server/src/exercises/dto/every-date.dto.ts
+++ b/server/src/exercises/dto/every-date.dto.ts
@@ -1,9 +1,12 @@
-import { Exercise } from "../entities/exercise.entity";
-
 export class EveryDateDto {
-  dateList!: string[];
+  dateList: string[] = [];
 
-  constructor(dateObject: Exercise[]) {
-    this.dateList = dateObject.map((object) => object.date);
+  constructor(dateObject: { date: string }[]) {
+    dateObject.map((item) => {
+      this.dateList.push(item.date);
+    });
+    this.dateList.sort((a, b) => {
+      return Number(a) - Number(b);
+    });
   }
 }

--- a/server/src/exercises/exercises.service.ts
+++ b/server/src/exercises/exercises.service.ts
@@ -13,9 +13,11 @@ export class ExercisesService {
   ) {}
 
   async findEveryExerciseDate(userId: number) {
-    const exerciseRows = await this.exerciseRepository.findBy({
-      user: { id: Equal(userId) },
-    });
+    const exerciseRows = await this.exerciseRepository
+      .createQueryBuilder("exercise")
+      .select("exercise.date")
+      .where("exercise.user_id = :userId", { userId })
+      .getMany();
     return new EveryDateDto(exerciseRows);
   }
 

--- a/server/src/exercises/exercises.service.ts
+++ b/server/src/exercises/exercises.service.ts
@@ -17,6 +17,7 @@ export class ExercisesService {
       .createQueryBuilder("exercise")
       .select("exercise.date")
       .where("exercise.user_id = :userId", { userId })
+      .orderBy("CAST (exercise.date AS SIGNED)", "ASC")
       .getMany();
     return new EveryDateDto(exerciseRows);
   }

--- a/server/src/exercises/exercises.service.ts
+++ b/server/src/exercises/exercises.service.ts
@@ -2,7 +2,7 @@ import { HistoryOfMonthDto } from "./dto/history-of-month.dto";
 import { Exercise } from "./entities/exercise.entity";
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Equal, Like, Repository } from "typeorm";
+import { Repository } from "typeorm";
 import { EveryDateDto } from "./dto/every-date.dto";
 
 @Injectable()
@@ -22,10 +22,11 @@ export class ExercisesService {
   }
 
   async findExerciseHistoryOfMonth(month: number, userId: number) {
-    const exerciseHistory = await this.exerciseRepository.findBy({
-      user: { id: Equal(userId) },
-      date: Like(`__${month.toString().padStart(2, "0")}__`),
-    });
+    const exerciseHistory = await this.exerciseRepository
+      .createQueryBuilder("exercise")
+      .where("exercise.user_id = :userId", { userId })
+      .andWhere("exercise.date like :date", { date: `__${month.toString().padStart(2, "0")}__` })
+      .getMany();
     return new HistoryOfMonthDto(exerciseHistory);
   }
 }

--- a/server/src/sbd_records/sbd_records.service.ts
+++ b/server/src/sbd_records/sbd_records.service.ts
@@ -22,15 +22,16 @@ export class SbdRecordsService {
   }
 
   async findBestSBDRecord(userId: number) {
-    let recordList = await this.recordsRepository.findBy({
-      user: { id: Equal(userId) },
-    });
-    if (recordList.length === 0) {
-      return { response: "User Not Exist" };
+    const recordList = await this.recordsRepository
+      .createQueryBuilder("SBD_record")
+      .where("SBD_record.user_id = :userId", { userId })
+      .orderBy("SBD_record.SBD_sum", "DESC")
+      .getOne();
+    if (!recordList) {
+      return {
+        response: "User Not Exist",
+      };
     }
-    recordList = recordList.sort((a, b) => {
-      return Number(b.SBD_sum) - Number(a.SBD_sum);
-    });
-    return new BestRecordDto(recordList[0]);
+    return new BestRecordDto(recordList);
   }
 }

--- a/server/src/sbd_records/sbd_records.service.ts
+++ b/server/src/sbd_records/sbd_records.service.ts
@@ -13,12 +13,11 @@ export class SbdRecordsService {
   ) {}
 
   async findEverySBDRecord(userId: number) {
-    let recordList = await this.recordsRepository.findBy({
-      user: { id: Equal(userId) },
-    });
-    recordList = recordList.sort((a, b) => {
-      return Number(a.date) - Number(b.date);
-    });
+    const recordList = await this.recordsRepository
+      .createQueryBuilder("SBD_record")
+      .where("SBD_record.user_id = :userId", { userId })
+      .orderBy("CAST(SBD_record.date AS SIGNED)", "ASC")
+      .getMany();
     return new EveryRecordDto(recordList);
   }
 


### PR DESCRIPTION
### 관련 이슈
외래키 관계 제약이 걸린 컬럼을 가져올 때 내부적으로 JOIN을 날려서 성능 이슈가 있었다.

TypeORM의 강점 중 하나인 queryBuilder 문법을 쓰면, 기존의 매서딩 방식에 비해 raw한 방식이지만 속도 향상을 기대할 수 있고,

쿼리 튜닝이 용이해서 JOIN을 쓰지 않고서도 외래키 관계 제약이 걸린 컬럼을 그냥 가져올 수 있는 큰 이점이 있다.


### 작업 사항
- [x] Find Every Exercise Date API 수정
- [x] Find History Of Month API 수정
- [x] Find Every SBD Record API 수정
- [x] Find Best SBD Record API 수정


### 작업 요약
Service 단의 모든 문법을 query builder 문법으로 수정

### 참고자료
[TypeORM - Query Builder 공식 문서](https://typeorm.io/select-query-builder#)
