### PR TITLE
[BE] ERD 최종본 바탕으로 Entity 수정

### DIFF
--- a/server/src/alarms/alarms.service.ts
+++ b/server/src/alarms/alarms.service.ts
@@ -13,7 +13,7 @@ export class AlarmsService {
   async countUnreadAlarm(userId: number) {
     const alarmCount = await this.alarmRepository
       .createQueryBuilder("alarm")
-      .where("alarm.receiver_user_id = :userId", { userId })
+      .where("alarm.user_id = :userId", { userId })
       .getCount();
     return { alarmCount };
   }

--- a/server/src/alarms/entities/alram.entity.ts
+++ b/server/src/alarms/entities/alram.entity.ts
@@ -6,18 +6,20 @@ export class Alarm {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column({ name: "receiver_user_id" })
-  receiverUserId!: number;
-
   @Column({ name: "sender_user_id" })
   senderUserId!: number;
 
   @Column({ name: "alarm_type" })
   alarmType!: number;
 
-  @Column({ name: "date", length: 45 })
-  date!: string;
+  @Column({ name: "minute_stamp" })
+  minuteStamp!: number;
 
   @Column({ name: "check" })
   check!: boolean;
+
+  // FK
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: "user_id", referencedColumnName: "id" })
+  user!: User;
 }

--- a/server/src/config/typeorm.config.ts
+++ b/server/src/config/typeorm.config.ts
@@ -16,6 +16,6 @@ export const typeormConfig: TypeOrmModuleOptions = {
   password: DB_PWD,
   database: DB_NAME,
   entities: [User, Routine, Exercise, Alarm, SBD_record, SBD_statistics, Follow],
-  synchronize: false,
+  synchronize: true,
   logging: true,
 };

--- a/server/src/exercises/entities/exercise.entity.ts
+++ b/server/src/exercises/entities/exercise.entity.ts
@@ -16,7 +16,7 @@ export class Exercise {
   date!: string;
 
   // FK
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { nullable: false })
   @JoinColumn({ name: "user_id" })
   user!: User;
 }

--- a/server/src/routines/entities/routine.entity.ts
+++ b/server/src/routines/entities/routine.entity.ts
@@ -16,7 +16,7 @@ export class Routine {
   exerciseString!: string;
 
   // FK
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { nullable: false })
   @JoinColumn({ name: "user_id", referencedColumnName: "id" })
   user!: User;
 }

--- a/server/src/sbd_records/entities/sbd_record.entity.ts
+++ b/server/src/sbd_records/entities/sbd_record.entity.ts
@@ -21,14 +21,14 @@ export class SBD_record {
   @Column({ name: "date", length: 45 })
   date!: string;
 
-  @Column({ name: "time_stamp", type: "bigint" })
-  timeStamp!: string;
+  @Column({ name: "second_stamp" })
+  secondStamp!: number;
 
   @Column({ name: "user_weight" })
   userWeight!: number;
 
   // FK
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { nullable: false })
   @JoinColumn({ name: "user_id" })
   user!: User;
 }

--- a/server/src/users/entities/user.entity.ts
+++ b/server/src/users/entities/user.entity.ts
@@ -2,13 +2,16 @@ import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity({ name: "user" })
 export class User {
-  @PrimaryGeneratedColumn()
+  @PrimaryGeneratedColumn({ name: "user_id" })
   id!: number;
 
   @Column({ name: "oauth_id", type: "bigint" })
   oauthId!: string;
 
-  @Column({ nullable: true, length: 45 })
+  @Column({ name: "profile_image", length: 180 })
+  profileImage!: string;
+
+  @Column({ length: 45 })
   name!: string;
 
   @Column({ nullable: true })
@@ -25,10 +28,6 @@ export class User {
 
   @Column({ nullable: true, length: 180 })
   introduce!: string;
-
-  // TODO: 이미지 컬럼은 일단 보류
-  // @Column({ name: "", length: 0 })
-  // profileImage!: string;
 
   @Column({ nullable: true })
   tier!: number;

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -41,10 +41,10 @@ export class UsersController {
     summary: "해당 사용자의 3대 챌린지 기록 반환",
   })
   @ApiQuery({
-    name: "id",
+    name: "userId",
     type: "number",
   })
-  async getRecentRecordTime(@Query("id") userId: number) {
+  async getRecentRecordTime(@Query("userId") userId: number) {
     return this.usersService.getRecentRecordTime(userId);
   }
 }


### PR DESCRIPTION
### 관련 이슈

ERD 설계도와 DB간의 동기화 및 최신화가 되지 않아
서로 컬럼 명과 그 의미를 까먹는 문제가 발생

하여 이를 최신화하기 위해 회의를 거친 결과 다음와 같은 PR을 작성하게 되었음

### 작업 사항
- [x] Alarm 테이블 외래키 관계 재설정
- [x] nullable: false 추가 및 네이밍 변경

### 작업 요약

다만 아래 사진을 보면 user 테이블의 컬럼들은 nullable 설정이 되어있는데,
이는 현재 Google OAuth 로그인과 회원 정보 기입의 실행 시점이 다르기 때문에
일시적으로 다음과 같이 설정해 놓았음

### 첨부

![image](https://user-images.githubusercontent.com/79911816/203508976-21aacf0b-a483-45d8-82da-ccd257d98c2a.png)


