### PR TITLE
[FE] 검색 페이지 - 메인 - 검색기능 및 사용자 추천 자동완성 기능

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import GlobalStyle from "@styles/GlobalStyle";
 import { RoutePath } from "@constants/enums";
 import HomePage from "@pages/HomePage";
+import SearchPage from "@pages/SearchPage";
 
 const App = () => {
   return (
@@ -10,6 +11,7 @@ const App = () => {
       <GlobalStyle />
       <Routes>
         <Route path={RoutePath.HOME} element={<HomePage />} />
+        <Route path={RoutePath.SEARCH} element={<SearchPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/components/SearchResultUserProfile/index.tsx
+++ b/client/src/components/SearchResultUserProfile/index.tsx
@@ -5,7 +5,7 @@ import * as s from "./style";
 export interface SearchResultUserProfileProps {
   profileImgUrl?: string;
   userName: string;
-  userMessage: string;
+  userMessage?: string;
 }
 
 const SearchResultUserProfile = ({

--- a/client/src/components/SearchResultUserProfile/style.ts
+++ b/client/src/components/SearchResultUserProfile/style.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import Theme from "@styles/Theme";
 
 export const Wrapper = styled.div`
-  height: 10vh;
+  height: 100%;
   background-color: ${({ theme }) => theme.COLORS.WHITE};
 `;
 
@@ -10,16 +10,14 @@ export const ProfileContainer = styled.div`
   height: 100%;
   display: flex;
   align-items: center;
-  padding: 0 1rem;
 `;
 
 export const ProfileImgContainer = styled.div`
-  width: 8vh;
-  height: 8vh;
+  height: 100%;
 `;
 
 export const UserInfoContainer = styled.div`
-  margin-left: 3vh;
+  margin-left: 3vw;
 `;
 
 export const UserNameContainer = styled.div`
@@ -30,7 +28,7 @@ export const UserNameContainer = styled.div`
 `;
 
 export const UserMessageContainer = styled.div`
-  color: ${({ userMessage, theme }: { userMessage: string; theme: typeof Theme }) => {
+  color: ${({ userMessage, theme }: { userMessage: string | undefined; theme: typeof Theme }) => {
     return userMessage ? theme.COLORS.DEEP_GRAY : theme.COLORS.PLACEHOLDER_GRAY;
   }};
   font-size: ${({ theme }) => theme.FONT_SIZE.EXTRA_SMALL};

--- a/client/src/pages/SearchPage/index.tsx
+++ b/client/src/pages/SearchPage/index.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from "react";
+import PageTemplate from "@pages/PageTemplate";
+import styled from "styled-components";
+import searchIcon from "@public/icons/btn_search.svg";
+import Theme from "@styles/Theme";
+import SearchResultUserProfile from "@components/SearchResultUserProfile";
+
+interface userProps {
+  id: number;
+  name: string;
+  introduce: string;
+}
+const SearchPage = () => {
+  const mockData = [
+    { id: 1, name: "최시운", introduce: "하이" },
+    { id: 2, name: "최지원", introduce: "난 아니야" },
+  ];
+
+  const [text, setText] = useState<string>("");
+  const [isText, setIsText] = useState(false);
+
+  // Zustand 대체 코드
+  const [store, setStore] = useState([]);
+  // 목데이터 유틸 함수 (tmp)
+  const searchEvent = (word: string) => {
+    const tmp = mockData.filter((user: { name: string; introduce: string }) =>
+      user.name.includes(word),
+    );
+    setStore(tmp);
+    return mockData.filter((user: { name: string; introduce: string }) => user.name.includes(word));
+  };
+
+  const dispatchResetStore = () => {
+    setStore([]);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+    const textLength: number = e.target.value.length;
+    if (textLength > 0) return setIsText(true);
+    return setIsText(false);
+  };
+
+  useEffect(() => {
+    const debounce = setTimeout(() => {
+      if (isText) searchEvent(text);
+      else dispatchResetStore();
+    }, 200);
+    return () => {
+      console.log("clear");
+      clearTimeout(debounce);
+    };
+  }, [text]);
+
+  const t = () => {
+    return store.map((user: object) => {
+      return (
+        <SearchResultUserProfile key={user.id} userName={user.name} userMessage={user.introduce} />
+      );
+    });
+  };
+
+  return (
+    <PageTemplate isRoot={false}>
+      <SearchContainer isText={isText}>
+        <UserSearchBarContainer>
+          <SearchBar
+            type="text"
+            onChange={handleChange}
+            isText={isText}
+            placeholder="검색어를 입력하세요."
+          />
+          <img src={searchIcon} alt="검색 아이콘" />
+        </UserSearchBarContainer>
+        <SearchResultContainer>{t()}</SearchResultContainer>
+      </SearchContainer>
+    </PageTemplate>
+  );
+};
+
+export default SearchPage;
+
+const SearchContainer = styled.div`
+  border-radius: 20px;
+  background-color: ${({ theme }) => theme.COLORS.WHITE};
+  width: 100%;
+  height: ${({ isText }: { isText: boolean }) => {
+    return isText ? "70vh" : "50px";
+  }};
+  padding: 0.5rem 5vw;
+  transition: 0.25s all;
+`;
+
+const UserSearchBarContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const SearchBar = styled.input`
+  width: 100%;
+  height: 40px;
+  background-color: transparent;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  border-bottom: ${({ theme, isText }: { theme: typeof Theme; isText: boolean }) => {
+    return isText ? `1px solid ${theme.COLORS.LIGHT_GRAY}` : "none";
+  }};
+`;
+
+const SearchResultContainer = styled.div`
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  transition: 1s all;
+`;

--- a/client/src/pages/SearchPage/styles.ts
+++ b/client/src/pages/SearchPage/styles.ts
@@ -1,8 +1,62 @@
 import styled from "styled-components";
+import Theme from "@styles/Theme";
 
 export const Wrapper = styled.div`
   gap: 20px;
   display: flex;
   flex-direction: column;
   align-items: center;
+`;
+
+export const SearchContainer = styled.div`
+  border-radius: 20px;
+  background-color: ${({ theme }) => theme.COLORS.WHITE};
+  width: 100%;
+  height: ${({ isText }: { isText: boolean }) => {
+    return isText ? "70vh" : "60px";
+  }};
+  padding: 1.3rem 5vw;
+  transition: 0.35s linear;
+`;
+
+export const UserSearchBarContainer = styled.div`
+  height: 30px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const SearchBar = styled.input`
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  border-bottom: ${({ theme, isText }: { theme: typeof Theme; isText: boolean }) => {
+    return isText ? `1px solid ${theme.COLORS.LIGHT_GRAY}` : "none";
+  }};
+`;
+
+export const SearchResultContainer = styled.div`
+  height: 90%;
+  margin-top: 20px;
+  justify-content: center;
+  align-items: center;
+  display: ${({ isText }: { isText: boolean }) => {
+    return isText ? "block" : "none";
+  }};
+  overflow: scroll;
+  -ms-overflow-style: none;
+
+  ::-webkit-scrollbar {
+    display: none;
+    width: 0 !important;
+  }
+`;
+
+export const UserProfile = styled.div`
+  padding: 5px 0;
+  height: 10%;
 `;

--- a/client/src/pages/SearchPage/styles.ts
+++ b/client/src/pages/SearchPage/styles.ts
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  gap: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;


### PR DESCRIPTION
### 관련 이슈
#128 

### 작업 사항
- [x] 레이아웃구성
- [x] 검색바에 입력시 창 크기 증가
- [x] 사용자 이름 검색시 자동완성 기능 구현
- [x] 추천된 사용자가 나타나는 박스 디자인 

### 작업 요약
사용자 이름을 입력하면 디바운싱을 하여, 입력이 끝나는 시점의 키워드를 받고 유저를 검색합니다.
1. 유저 리스트를 맨 처음 화면 랜더링시 받아옵니다.
2. 검색 시, 받아온 유저 리스트를 기반으로 탐색합니다.

* 모든 자기소개가 존재하지 않고 프로필이미지가 동일 한 것은 현재 사용하는 정보가 user.name뿐이기 때문입니다.
* 현재 백엔드에서는 id, name, introduce, img에 대한 정보가 필요합니다.
* 그러나 현재의 userlist는 name만 반환하여 map의 고유한 key값을 설정하지 못했고 이러한 이유로 영상에서 오류가 발생할 수 있습니다.
* userList로 넘겨주는 형태에 대해서 고려해봐야할 것 같습니다.

### 첨부

https://user-images.githubusercontent.com/78866590/203785714-28574120-19c2-4b35-9a78-8abf95016e54.mov


### 참고자료
- https://www.youtube.com/watch?v=By49qqkzmzA
- https://blog.hubspot.com/website/css-transition-vs-animation
- https://minoo.medium.com/%EB%B2%88%EC%97%AD-5%EA%B0%80%EC%A7%80-%EB%A6%AC%EC%95%A1%ED%8A%B8-%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98-%EC%9E%A5-%EB%8B%A8%EC%A0%90-%EB%B9%84%EA%B5%90-react-animations-in-depth-884ff6e61b88
