### PR TITLE
서버 배포 1차 - CORS 오류 해결

### DIFF
--- a/client/src/pages/SearchPage/index.tsx
+++ b/client/src/pages/SearchPage/index.tsx
@@ -34,15 +34,9 @@ const SearchPage = () => {
   useEffect(() => {
     const url = `${process.env.SERVER_BASE_URL}${process.env.GET_USERLIST_API}`;
     const getUserList = async () => {
-      await axios
-        .get(url, {
-          method: "GET",
-          headers: { "Content-Type": "application/json" },
-          withCredentials: true,
-        })
-        .then((response) => {
-          setUserList(response.data.response.userProfileList);
-        });
+      await axios.get(url, { withCredentials: true }).then((response) => {
+        setUserList(response.data.response.userProfileList);
+      });
     };
     getUserList();
   }, []);

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -16,11 +16,9 @@ async function bootstrap() {
   app.useGlobalFilters(new HttpExceptionFilter()); // 전역 필터 적용
 
   app.enableCors({
-    origin: ["http://localhost:8080", "https://www.fitory.ga", "http://localhost:3000"],
+    origin: ["https://www.fitory.ga", "https://fitory.ga"],
     methods: ["GET", "POST", "OPTIONS"],
-    allowedHeaders: ["access-control-allow-origin", "X-Requested-With", "Content-Type", "Accept"],
     credentials: true,
-    optionsSuccessStatus: 204,
   });
 
   app.use(cookieParser());


### PR DESCRIPTION
### 관련 이슈
- 배포 서버에서 api 서버 접속이 CORS 오류 발생

### 작업 사항
- [x] search page의 axios에 `withCredentials: true` 설정 추가
- [x] server의 main.ts `origin: ["https://www.fitory.ga", "https://fitory.ga"]`, `credentials: true` 설정 추가
- [x] nginx에서 localhost:8080번의 proxy_pass 추가

### 작업 요약
- search page의 axios에 `withCredentials: true` 설정 추가
- server의 main.ts `origin: ["https://www.fitory.ga", "https://fitory.ga"]`, `credentials: true` 설정 추가
- nginx에서 localhost:8080번의 proxy_pass 추가

### 첨부
![image](https://user-images.githubusercontent.com/70889358/203921285-14135022-57cc-4943-9516-2b88349b22b8.png)


### 참고자료
[[ERROR] The 'Access-Control-Allow-Origin' header contains multiple values](https://minholee93.tistory.com/entry/ERROR-The-Access-Control-Allow-Origin-header-contains-multiple-values)

[[WEB] 📚 악명 높은 CORS 개념 & 해결법 - 정리 끝판왕 👏](https://inpa.tistory.com/entry/WEB-%F0%9F%93%9A-CORS-%F0%9F%92%AF-%EC%A0%95%EB%A6%AC-%ED%95%B4%EA%B2%B0-%EB%B0%A9%EB%B2%95-%F0%9F%91%8F)

[[Nginx] CORS 설정](https://greeng00se.tistory.com/119)

[CORS 정복기](https://velog.io/@prayme/CORS-%EC%A0%95%EB%B3%B5%EA%B8%B0)