### PR TITLE
[BE] API 구현 - AUTH API - Google OAuth 프론트와의 연동성 수정

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
+        "@nestjs/axios": "^1.0.0",
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/jwt": "^9.0.0",
@@ -1504,6 +1505,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@nestjs/axios": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-1.0.0.tgz",
+      "integrity": "sha512-DzBIhmBPgPAf/Hf4oHVgNNrcYcmAwV6v1TeZFkEaotO5AtXEfCJ6c07Po4EmylAA0PFp+8+S77PBEcLNEMOCGQ==",
+      "dependencies": {
+        "axios": "1.1.3"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -3015,8 +3029,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axe-core": {
       "version": "4.5.2",
@@ -3026,6 +3039,16 @@
       "peer": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -3682,7 +3705,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3957,7 +3979,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5180,6 +5201,25 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.13.tgz",
@@ -5234,7 +5274,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8379,6 +8418,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -11534,6 +11578,14 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@nestjs/axios": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-1.0.0.tgz",
+      "integrity": "sha512-DzBIhmBPgPAf/Hf4oHVgNNrcYcmAwV6v1TeZFkEaotO5AtXEfCJ6c07Po4EmylAA0PFp+8+S77PBEcLNEMOCGQ==",
+      "requires": {
+        "axios": "1.1.3"
+      }
+    },
     "@nestjs/cli": {
       "version": "9.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-9.1.5.tgz",
@@ -12708,8 +12760,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axe-core": {
       "version": "4.5.2",
@@ -12717,6 +12768,16 @@
       "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
       "dev": true,
       "peer": true
+    },
+    "axios": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -13193,7 +13254,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -13404,8 +13464,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "denque": {
       "version": "2.1.0",
@@ -14361,6 +14420,11 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "fork-ts-checker-webpack-plugin": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.13.tgz",
@@ -14397,7 +14461,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -16740,6 +16803,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
+    "@nestjs/axios": "^1.0.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/jwt": "^9.0.0",

--- a/server/src/domain/oauth/google-oauth/dto/access-token.dto.ts
+++ b/server/src/domain/oauth/google-oauth/dto/access-token.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString } from "class-validator";
+
+export class AccessTokenDto {
+  @ApiProperty({
+    description: "유저의 Access_token",
+    type: String,
+  })
+  @IsString()
+  accessToken: string;
+}

--- a/server/src/domain/oauth/google-oauth/google-oauth.controller.ts
+++ b/server/src/domain/oauth/google-oauth/google-oauth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Inject, Post, Res, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, HttpStatus, Inject, Post, Res, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { Response } from "express";
 import { ApiOperation, ApiTags } from "@nestjs/swagger";
@@ -34,14 +34,18 @@ export class GoogleOauthController {
       name: userInfo.data.name,
     });
 
-    res.cookie("access_token", token, {
-      sameSite: true,
-      secure: false, // 배포시에는 true로 바꿔야됨
-      httpOnly: true,
-      maxAge: 2 * 60 * 60 * 1000, // (2 hours) 나중에 maxAge 합의 필요
-    });
+    if (token) {
+      res.cookie("access_token", token, {
+        sameSite: true,
+        secure: false, // 배포시에는 true로 바꿔야됨
+        httpOnly: true,
+        maxAge: 2 * 60 * 60 * 1000, // (2 hours) 나중에 maxAge 합의 필요
+      });
 
-    return res.send(userInfo.data.name);
+      return true;
+    }
+
+    return false;
   }
 
   @Get("logout")

--- a/server/src/domain/oauth/google-oauth/google-oauth.controller.ts
+++ b/server/src/domain/oauth/google-oauth/google-oauth.controller.ts
@@ -1,9 +1,9 @@
-import { Controller, Get, Inject, Req, Res, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, Inject, Post, Res, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { Response } from "express";
 import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { AccessTokenDto } from "@oauth/google-oauth/dto/access-token.dto";
 import { GoogleOauthService } from "./google-oauth.service";
-import { RequestWithUser } from "@type/request";
 
 @Controller("api/oauth/google")
 @ApiTags("OAUTH API")
@@ -20,13 +20,19 @@ export class GoogleOauthController {
     return { msg: "Google Authentication" };
   }
 
-  @Get("callback")
-  @UseGuards(AuthGuard("google"))
+  @Post("validate")
   @ApiOperation({
     summary: "구글 로그인 callback, 쿠키 생성 후 사용자에게 전송",
   })
-  async googleOAuthCallback(@Req() req: RequestWithUser, @Res() res: Response) {
-    const token = await this.googleOauthService.signIn(req.user);
+  async googleOAuthValidate(@Body() body: AccessTokenDto, @Res() res: Response) {
+    const { accessToken } = body;
+
+    const userInfo = await this.googleOauthService.getUserInfo(accessToken);
+
+    const token = await this.googleOauthService.signIn({
+      oauthId: userInfo.data.sub,
+      name: userInfo.data.name,
+    });
 
     res.cookie("access_token", token, {
       sameSite: true,
@@ -35,7 +41,7 @@ export class GoogleOauthController {
       maxAge: 2 * 60 * 60 * 1000, // (2 hours) 나중에 maxAge 합의 필요
     });
 
-    return res.send(req.user);
+    return res.send(userInfo.data.name);
   }
 
   @Get("logout")

--- a/server/src/domain/oauth/google-oauth/google-oauth.controller.ts
+++ b/server/src/domain/oauth/google-oauth/google-oauth.controller.ts
@@ -3,6 +3,7 @@ import { AuthGuard } from "@nestjs/passport";
 import { Response } from "express";
 import { ApiOperation, ApiTags } from "@nestjs/swagger";
 import { AccessTokenDto } from "@oauth/google-oauth/dto/access-token.dto";
+import { HttpResponse } from "@converter/response.converter";
 import { GoogleOauthService } from "./google-oauth.service";
 
 @Controller("api/oauth/google")
@@ -42,10 +43,10 @@ export class GoogleOauthController {
         maxAge: 2 * 60 * 60 * 1000, // (2 hours) 나중에 maxAge 합의 필요
       });
 
-      return true;
+      return HttpResponse.success({ validate: true });
     }
 
-    return false;
+    return HttpResponse.success({ validate: false });
   }
 
   @Get("logout")

--- a/server/src/domain/oauth/google-oauth/google-oauth.controller.ts
+++ b/server/src/domain/oauth/google-oauth/google-oauth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpStatus, Inject, Post, Res, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, Inject, Post, Res, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { Response } from "express";
 import { ApiOperation, ApiTags } from "@nestjs/swagger";

--- a/server/src/domain/oauth/google-oauth/google-oauth.module.ts
+++ b/server/src/domain/oauth/google-oauth/google-oauth.module.ts
@@ -2,14 +2,16 @@ import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { User } from "src/domain/users/entities/user.entity";
 import { JwtModule } from "@nestjs/jwt";
+import { ACCESS_TOKEN_EXPIRESIN, ACCESS_TOKEN_SECRETKEY } from "@env";
+import { HttpModule } from "@nestjs/axios";
 import { GoogleOauthController } from "./google-oauth.controller";
 import { GoogleStrategy } from "./utils/google.strategy";
 import { GoogleOauthService } from "./google-oauth.service";
 import { JwtStrategy } from "../jwt/jwt.strategy";
-import { ACCESS_TOKEN_EXPIRESIN, ACCESS_TOKEN_SECRETKEY } from "@env";
 
 @Module({
   imports: [
+    HttpModule,
     TypeOrmModule.forFeature([User]),
     JwtModule.register({
       secret: ACCESS_TOKEN_SECRETKEY,

--- a/server/src/domain/oauth/google-oauth/google-oauth.service.ts
+++ b/server/src/domain/oauth/google-oauth/google-oauth.service.ts
@@ -25,9 +25,15 @@ export class GoogleOauthService {
       throw new BadRequestException("Unauthenticated");
     }
 
-    return this.generateJwt({
-      sub: user.oauthId,
-    });
+    const userExists = await this.findUserById(user.oauthId);
+
+    if (!userExists) {
+      return this.generateJwt({
+        sub: userExists.oauthId,
+      });
+    }
+
+    return null;
   }
 
   getUserInfo(accessToken: string) {
@@ -36,5 +42,18 @@ export class GoogleOauthService {
         `https://www.googleapis.com/oauth2/v1/userinfo?access_token=${accessToken}`,
       ),
     );
+  }
+
+  async findUserById(oauthId: string) {
+    const user = await this.userRepository
+      .createQueryBuilder("user")
+      .where("user.oauth_id = :oauthId", { oauthId })
+      .getOne();
+
+    if (!user) {
+      return null;
+    }
+
+    return user;
   }
 }

--- a/server/src/domain/oauth/google-oauth/google-oauth.service.ts
+++ b/server/src/domain/oauth/google-oauth/google-oauth.service.ts
@@ -4,6 +4,8 @@ import { Repository } from "typeorm";
 import { User } from "src/domain/users/entities/user.entity";
 import { JwtService } from "@nestjs/jwt";
 import { JwtPayload } from "@type/jwt";
+import { firstValueFrom } from "rxjs";
+import { HttpService } from "@nestjs/axios";
 import { GoogleUserDto } from "./dto/google-user.dto";
 
 @Injectable()
@@ -11,6 +13,7 @@ export class GoogleOauthService {
   constructor(
     @InjectRepository(User) private readonly userRepository: Repository<User>,
     private jwtService: JwtService,
+    private readonly httpService: HttpService,
   ) {}
 
   generateJwt(payload: JwtPayload) {
@@ -22,37 +25,16 @@ export class GoogleOauthService {
       throw new BadRequestException("Unauthenticated");
     }
 
-    const userExists = await this.findUserById(user.oauthId);
-
-    if (!userExists) {
-      return this.registerUser(user);
-    }
-
     return this.generateJwt({
-      sub: userExists.oauthId,
+      sub: user.oauthId,
     });
   }
 
-  async registerUser(user: GoogleUserDto) {
-    try {
-      return this.generateJwt({
-        sub: user.oauthId,
-      });
-    } catch {
-      throw new InternalServerErrorException();
-    }
-  }
-
-  async findUserById(oauthId: string) {
-    const user = await this.userRepository
-      .createQueryBuilder("user")
-      .where("user.oauth_id = :oauthId", { oauthId })
-      .getOne();
-
-    if (!user) {
-      return null;
-    }
-
-    return user;
+  getUserInfo(accessToken: string) {
+    return firstValueFrom(
+      this.httpService.get(
+        `https://www.googleapis.com/oauth2/v1/userinfo?access_token=${accessToken}`,
+      ),
+    );
   }
 }

--- a/server/src/domain/oauth/google-oauth/utils/google.strategy.ts
+++ b/server/src/domain/oauth/google-oauth/utils/google.strategy.ts
@@ -2,7 +2,7 @@ import { PassportStrategy } from "@nestjs/passport";
 import { Strategy, VerifyCallback } from "passport-google-oauth20";
 import { Inject, Injectable } from "@nestjs/common";
 import { Profile } from "passport";
-import { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT } from "../../../../utils/env";
+import { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT } from "@env";
 import { GoogleOauthService } from "../google-oauth.service";
 
 @Injectable()


### PR DESCRIPTION
### 작업 사항
- [x] access_token POST API
- [x] access_token을 기반으로 Google API에 인증 요청 + 유저 정보 요청
- [x] 클라이언트측으로 jwt 전송

### 작업 요약
- 기존에는 프론트측과의 통신을 고려하지 않은 채 구현이 되어있었다.
- 프론트측과 얘기를 나눠 API에 대한 협의를 했다.
- 이를 토대로 API를 재구성한다.
- ❗️현재 프론트랑 같이 디버깅을 해보지 않아서 문제 발생시 바로 알려주세요.
- 신규 유저일 경우 jwt 토근과 함께 `statusCode : 200, validate: true` 를 보냅니다.
- 이미 회원가입한 유저일 경우 `statusCode : 200, validate: false` 를 보냅니다.
  - ❗️`동규님` 아니면 404같은 에러코드로 보내드릴까요?

### 첨부
> 작업한 사진을 첨부할 경우 여기에 추가하세요.
