### PR TITLE
[BE] API 구현 - ROUTINE API - Save Routine API

### DIFF
--- a/server/src/domain/exercises/dto/exercise.dto.ts
+++ b/server/src/domain/exercises/dto/exercise.dto.ts
@@ -1,11 +1,9 @@
 import {
   ArrayNotEmpty,
   IsArray,
-  IsDate,
   IsNotEmpty,
   IsNumber,
   IsString,
-  Length,
   Matches,
   Max,
   Min,

--- a/server/src/domain/exercises/exercises.service.ts
+++ b/server/src/domain/exercises/exercises.service.ts
@@ -1,11 +1,11 @@
-import { User } from "./../users/entities/user.entity";
 import { HttpResponse } from "@converter/response.converter";
-import { exerciseConverter } from "./converter/exercise.converter";
-import { Exercise } from "./entities/exercise.entity";
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Exception } from "src/exception/exceptions";
+import { Exercise } from "./entities/exercise.entity";
+import { exerciseConverter } from "./converter/exercise.converter";
+import { User } from "../users/entities/user.entity";
 import { ExerciseDataDto } from "./dto/exercise.dto";
 
 @Injectable()
@@ -51,21 +51,17 @@ export class ExercisesService {
 
   async submitSingleSBDRecord(exerciseData: ExerciseDataDto) {
     try {
-      const userObject = await this.userRepository
-        .createQueryBuilder("user")
-        .where("user.user_id = :userId", { userId: exerciseData.userId })
-        .getOne();
       await Promise.all(
         exerciseData.exerciseList.map(async (exercise) => {
           const setString = exercise.setList.reduce((acc, cur) => {
-            return acc + "|" + cur.kg + "/" + cur.count + "/" + cur.check;
+            return `${acc}|${cur.kg}/${cur.count}/${cur.check}`;
           }, "");
-          console.log(exerciseData.userId);
+
           await this.exerciseRepository.save({
             exerciseName: exercise.exerciseName,
-            exerciseString: setString.substring(1),
+            exerciseString: setString.slice(1),
             date: exerciseData.date,
-            user: userObject,
+            user: { id: exerciseData.userId },
           });
         }),
       );
@@ -87,7 +83,7 @@ export class ExercisesService {
   }
 
   async getTotalExerciseDate(userId: number) {
-    return await this.exerciseRepository
+    return this.exerciseRepository
       .createQueryBuilder("exercise")
       .select("exercise.date")
       .where("exercise.user_id = :userId", { userId })

--- a/server/src/domain/routines/converter/routines.converter.ts
+++ b/server/src/domain/routines/converter/routines.converter.ts
@@ -1,3 +1,4 @@
+import { routineSet } from "@type/domain";
 import { Routine } from "../entities/routine.entity";
 
 export const routineConverter = {
@@ -11,5 +12,24 @@ export const routineConverter = {
         result.push(routine.routineName);
       });
     return result;
+  },
+
+  routineDetailList: (routineList: Routine[]) => {
+    const routineDetailObject: {
+      [routineName: string]: { [exerciseName: string]: routineSet[] }[];
+    } = {};
+    routineList.map((routine: Routine) => {
+      routineDetailObject[routine.routineName] = [];
+      const exerciseList: routineSet[] = [];
+      routine.exerciseString.split("|").map((singleExercise, index) => {
+        const [kg, count] = singleExercise.split("/").map((item) => Number(item));
+        exerciseList.push({ index: index + 1, kg, count });
+      });
+
+      routineDetailObject[routine.routineName].push({
+        [routine.exerciseName]: exerciseList,
+      });
+    });
+    return routineDetailObject;
   },
 };

--- a/server/src/domain/routines/converter/routines.converter.ts
+++ b/server/src/domain/routines/converter/routines.converter.ts
@@ -1,4 +1,5 @@
 import { routineSet } from "@type/domain";
+import { RoutineDto, SingleExercise } from "@routine/dto/single-routine.dto";
 import { Routine } from "../entities/routine.entity";
 
 export const routineConverter = {
@@ -16,7 +17,7 @@ export const routineConverter = {
 
   routineDetailList: (routineList: Routine[]) => {
     const routineDetailObject: {
-      [routineName: string]: { [exerciseName: string]: routineSet[] }[];
+      [routineName: string]: { name: string; set: routineSet[] }[];
     } = {};
     routineList.map((routine: Routine) => {
       routineDetailObject[routine.routineName] = [];
@@ -27,9 +28,16 @@ export const routineConverter = {
       });
 
       routineDetailObject[routine.routineName].push({
-        [routine.exerciseName]: exerciseList,
+        name: routine.exerciseName,
+        set: exerciseList,
       });
     });
     return routineDetailObject;
+  },
+
+  routineObjectToString: (exerciseList: SingleExercise) => {
+    return exerciseList.setList.reduce((acc, cur) => {
+      return `${acc}|${cur.kg}/${cur.count}`;
+    }, "");
   },
 };

--- a/server/src/domain/routines/dto/single-routine.dto.ts
+++ b/server/src/domain/routines/dto/single-routine.dto.ts
@@ -1,5 +1,15 @@
-import { IsNumber, IsString, Matches, Min } from "class-validator";
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  Max,
+  Min,
+  ValidateNested,
+} from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "class-transformer";
 
 export class RoutineDto {
   @ApiProperty({
@@ -18,17 +28,54 @@ export class RoutineDto {
   routineName: string;
 
   @ApiProperty({
+    description: "운동 배열",
+    type: () => [SingleExercise],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @Type(() => SingleExercise)
+  @ValidateNested({ each: true })
+  exerciseList: SingleExercise[];
+}
+
+export class SingleExercise {
+  @ApiProperty({
     description: "운동 이름",
     type: String,
   })
+  @IsNotEmpty()
   @IsString()
   exerciseName: string;
 
   @ApiProperty({
-    description: "운동 기록 문자열 ex) 90/7|90/7|70/5",
-    type: String,
+    description: "운동 배열",
+    type: () => [SingleSet],
   })
-  @IsString()
-  @Matches("^[0-9|/||]+$")
-  exerciseString: string;
+  @IsArray()
+  @ArrayNotEmpty()
+  @Type(() => SingleSet)
+  @ValidateNested({ each: true })
+  setList: SingleSet[];
+}
+
+export class SingleSet {
+  @ApiProperty({
+    description: "중량",
+    type: Number,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  @Min(0)
+  @Max(1000)
+  kg: number;
+
+  @ApiProperty({
+    description: "반복 횟수",
+    type: Number,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  count: number;
 }

--- a/server/src/domain/routines/dto/single-routine.dto.ts
+++ b/server/src/domain/routines/dto/single-routine.dto.ts
@@ -1,7 +1,7 @@
 import { IsNumber, IsString, Min } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
 
-export class SingleRoutineoDto {
+export class RoutineDto {
   @ApiProperty({
     description: "유저의 고유 ID",
     type: Number,

--- a/server/src/domain/routines/routines.controller.ts
+++ b/server/src/domain/routines/routines.controller.ts
@@ -3,6 +3,7 @@ import { Body, Controller, Get, Post, Query } from "@nestjs/common";
 import { ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { isValidUserId } from "@validation/validation";
 import { Exception } from "@exception/exceptions";
+import { HttpResponse } from "@converter/response.converter";
 import { RoutinesService } from "./routines.service";
 import { RoutineDto } from "./dto/single-routine.dto";
 
@@ -56,7 +57,9 @@ export class RoutinesController {
   @ApiOperation({
     summary: "루틴 저장",
   })
-  saveRoutine(@Body() routineData: RoutineDto) {
-    return this.routinesService.saveRoutine(routineData);
+  async saveRoutine(@Body() routineData: RoutineDto) {
+    await this.routinesService.saveRoutine(routineData);
+
+    return HttpResponse.success("Routine save success");
   }
 }

--- a/server/src/domain/routines/routines.controller.ts
+++ b/server/src/domain/routines/routines.controller.ts
@@ -4,7 +4,7 @@ import { ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { isValidUserId } from "@validation/validation";
 import { Exception } from "@exception/exceptions";
 import { RoutinesService } from "./routines.service";
-import { SingleRoutineoDto } from "./dto/single-routine.dto";
+import { RoutineDto } from "./dto/single-routine.dto";
 
 @Controller("api/routines")
 @ApiTags("ROUTINE API")
@@ -54,9 +54,9 @@ export class RoutinesController {
 
   @Post("save")
   @ApiOperation({
-    summary: "❌ 미구현) 해당 루틴을 저장",
+    summary: "루틴 저장",
   })
-  registerUser(@Body() routineData: SingleRoutineoDto) {
-    return this.routinesService.saveSingleRoutine(routineData);
+  saveRoutine(@Body() routineData: RoutineDto) {
+    return this.routinesService.saveRoutine(routineData);
   }
 }

--- a/server/src/exception/exceptions.ts
+++ b/server/src/exception/exceptions.ts
@@ -38,7 +38,7 @@ export class Exception {
     const response = HttpResponse.failed(HttpStatus.UNAUTHORIZED, "Unauthorized");
     return new UnauthorizedException(response);
   }
-  
+
   invalidFileType(): HttpException {
     const response = HttpResponse.failed(HttpStatus.FORBIDDEN, "Invalid File Type");
     return new ForbiddenException(response);
@@ -46,6 +46,11 @@ export class Exception {
 
   fileSubmitError(): HttpException {
     const response = HttpResponse.failed(HttpStatus.FORBIDDEN, "File Sumit Error");
+    return new ForbiddenException(response);
+  }
+
+  routineNameDuplicate(): HttpException {
+    const response = HttpResponse.failed(HttpStatus.BAD_REQUEST, "Routine Name Duplicate");
     return new ForbiddenException(response);
   }
 }

--- a/server/src/types/domain.d.ts
+++ b/server/src/types/domain.d.ts
@@ -13,3 +13,9 @@ export interface recordItem {
   date: string;
   userWeight: number;
 }
+
+export interface routineSet {
+  index: number;
+  kg: number;
+  count: number;
+}


### PR DESCRIPTION
### 작업 사항
- [x] 루틴 이름 중복 검사
- [x] 저장시 루틴에 대한 정보를 클라이언트에서 받아와 DB에 저장한다.

### 작업 요약
- POST 형식
```
{
  "userId": 1,
  "routineName": "테스트 루틴",
  "exerciseList": [
    {
      "exerciseName": "테스트 운동",
      "setList": [
        {
          "kg": 100,
          "count": 5
        }
      ]
    },
{
      "exerciseName": "테스트 운동2",
      "setList": [
        {
          "kg": 200,
          "count": 10
        }
      ]
    }
  ]
}
```
- Response
```
{
  "ok": true,
  "statusCode": 200,
  "response": "Routine save success"
}
```
- 클라이언트에서 온 루틴 정보를 파싱해서 DB에 저장한다.

### 첨부
<img width="949" alt="스크린샷 2022-12-01 오후 10 32 11" src="https://user-images.githubusercontent.com/70889358/205065823-22ce28c5-b029-461a-a94b-731277acd6a7.png">