### PR TITLE
[BE] API - Alarm 읽음 처리 구현

### DIFF
--- a/server/src/domain/alarms/alarms.service.ts
+++ b/server/src/domain/alarms/alarms.service.ts
@@ -36,7 +36,7 @@ export class AlarmsService {
       .addSelect("alarm.time_stamp", "time_stamp")
       .innerJoin(User, "user", "user.user_id = alarm.sender_user_id")
       .where("alarm.user_id = :userId", { userId })
-      .andWhere("alarm.check = false")
+      .andWhere("DATE(alarm.time_stamp) >= DATE_ADD(NOW(), INTERVAL -1 MONTH)")
       .getRawMany();
     await this.checkToReadAlarm(userId);
     return HttpResponse.success({

--- a/server/src/domain/alarms/alarms.service.ts
+++ b/server/src/domain/alarms/alarms.service.ts
@@ -17,6 +17,7 @@ export class AlarmsService {
     const alarmCount = await this.alarmRepository
       .createQueryBuilder("alarm")
       .where("alarm.user_id = :userId", { userId })
+      .andWhere("alarm.check = false")
       .getCount();
     return HttpResponse.success({
       alarmCount,
@@ -35,6 +36,7 @@ export class AlarmsService {
       .addSelect("alarm.time_stamp", "time_stamp")
       .innerJoin(User, "user", "user.user_id = alarm.sender_user_id")
       .where("alarm.user_id = :userId", { userId })
+      .andWhere("alarm.check = false")
       .getRawMany();
     await this.checkToReadAlarm(userId);
     return HttpResponse.success({

--- a/server/src/domain/alarms/alarms.service.ts
+++ b/server/src/domain/alarms/alarms.service.ts
@@ -1,3 +1,4 @@
+import { Exception } from "@exception/exceptions";
 import { HttpResponse } from "@converter/response.converter";
 import { Alarm } from "./entities/alram.entity";
 import { Injectable } from "@nestjs/common";
@@ -35,8 +36,18 @@ export class AlarmsService {
       .innerJoin(User, "user", "user.user_id = alarm.sender_user_id")
       .where("alarm.user_id = :userId", { userId })
       .getRawMany();
+    await this.checkToReadAlarm(userId);
     return HttpResponse.success({
       alarmObject,
     });
+  }
+
+  async checkToReadAlarm(userId: number) {
+    await this.alarmRepository
+      .createQueryBuilder("alarm")
+      .update(Alarm)
+      .set({ check: true })
+      .where("user_id = :userId", { userId })
+      .execute();
   }
 }

--- a/server/src/domain/follows/follows.service.ts
+++ b/server/src/domain/follows/follows.service.ts
@@ -33,7 +33,7 @@ export class FollowsService {
   }
 
   async getFollowerUserList(userId: number) {
-    const followingUserProfileList = await this.followRepository
+    const followerUserProfileList = await this.followRepository
       .createQueryBuilder("follow")
       .select("follow.followed_id", "followed_id")
       .addSelect("user.name", "name")
@@ -44,7 +44,7 @@ export class FollowsService {
       .andWhere("follow.deleted = false")
       .getRawMany();
     return HttpResponse.success({
-      followingUserProfileList,
+      followerUserProfileList,
     });
   }
 

--- a/server/src/domain/users/users.service.ts
+++ b/server/src/domain/users/users.service.ts
@@ -1,4 +1,5 @@
 import { HttpResponse } from "@converter/response.converter";
+import { Exception } from "@exception/exceptions";
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";


### PR DESCRIPTION
### 관련 이슈

#284 

### 작업 사항
- [x] 알림 읽음 표시 로직 구현
- [x] 안읽은 알람만 가져오도록 where절 수정
- [x] 한 달 유효기간 필터링 구현

### 작업 요약

사용자가 Alarm 페이지 접속 시 요청하는 API에

알림 읽음 표시 로직을 붙여서 작동하도록 수정

또한 알림 페이지에서는
`안읽은 알림` + `읽었지만 아직 1달이 지나지 않은 알림`
이렇게 랜더링되도록 필터링 구현


