### PR TITLE
[BE] date를 서버 시간으로 조정

### DIFF
--- a/server/src/domain/exercises/dto/exercise.dto.ts
+++ b/server/src/domain/exercises/dto/exercise.dto.ts
@@ -23,15 +23,6 @@ export class ExerciseDataDto {
   userId: number;
 
   @ApiProperty({
-    description: "기록 제출 날짜",
-    type: String,
-  })
-  @IsNotEmpty()
-  @IsString()
-  @Matches("^([0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[1,2][0-9]|3[0,1]))$")
-  date: string;
-
-  @ApiProperty({
     description: "운동 배열",
     type: () => [SingleExercise],
   })

--- a/server/src/domain/exercises/exercises.service.ts
+++ b/server/src/domain/exercises/exercises.service.ts
@@ -7,6 +7,7 @@ import { Exercise } from "./entities/exercise.entity";
 import { exerciseConverter } from "./converter/exercise.converter";
 import { User } from "../users/entities/user.entity";
 import { ExerciseDataDto } from "./dto/exercise.dto";
+import dayjs from "dayjs";
 
 @Injectable()
 export class ExercisesService {
@@ -60,7 +61,7 @@ export class ExercisesService {
           await this.exerciseRepository.save({
             exerciseName: exercise.exerciseName,
             exerciseString: setString.slice(1),
-            date: exerciseData.date,
+            date: dayjs().format("YYMMDD"),
             user: { id: exerciseData.userId },
           });
         }),

--- a/server/src/domain/mock/mock.service.ts
+++ b/server/src/domain/mock/mock.service.ts
@@ -130,7 +130,6 @@ export class MockService {
             benchpress,
             SBD_sum: squat + deadlift + benchpress,
             timeStamp: dayjs(randomDateString).format("YYYY-MM-DD HH:mm:ss"),
-            date: dayjs(randomDateString).format("YYMMDD"),
           })
           .insert()
           .execute();

--- a/server/src/domain/sbd_records/converter/sbd_records.converter.ts
+++ b/server/src/domain/sbd_records/converter/sbd_records.converter.ts
@@ -12,7 +12,7 @@ export const recordConverter = {
           deadlift: record.deadlift,
           benchpress: record.benchpress,
           SBD_sum: record.SBD_sum,
-          date: record.date,
+          timeStamp: record.timeStamp,
           userWeight: record.userWeight,
         },
       });

--- a/server/src/domain/sbd_records/entities/sbd_record.entity.ts
+++ b/server/src/domain/sbd_records/entities/sbd_record.entity.ts
@@ -25,9 +25,6 @@ export class SBD_record {
   @Column({ name: "SBD_sum" })
   SBD_sum!: number;
 
-  @Column({ name: "date", length: 45 })
-  date!: string;
-
   @CreateDateColumn({
     name: "time_stamp",
     type: "timestamp",

--- a/server/src/domain/sbd_records/sbd_records.service.ts
+++ b/server/src/domain/sbd_records/sbd_records.service.ts
@@ -23,7 +23,7 @@ export class SbdRecordsService {
     const recordList = await this.recordsRepository
       .createQueryBuilder("SBD_record")
       .where("SBD_record.user_id = :userId", { userId })
-      .orderBy("CAST(SBD_record.date AS SIGNED)", "ASC")
+      .orderBy("SBD_record.time_stamp", "ASC")
       .getMany();
     return HttpResponse.success({
       recordList: recordConverter.everyRecord(recordList),

--- a/server/src/domain/users/entities/user.entity.ts
+++ b/server/src/domain/users/entities/user.entity.ts
@@ -14,30 +14,30 @@ export class User {
   @Column({ length: 45 })
   name!: string;
 
-  @Column({ nullable: true })
+  @Column({})
   age!: number;
 
-  @Column({ nullable: true })
+  @Column({})
   gender!: number;
 
-  @Column({ nullable: true })
+  @Column({})
   height!: number;
 
-  @Column({ nullable: true })
+  @Column({})
   weight!: number;
 
-  @Column({ nullable: true, length: 180 })
+  @Column({ length: 180, default: "-" })
   introduce!: string;
 
-  @Column({ nullable: true })
+  @Column({ default: 0 })
   tier!: number;
 
-  @Column({ nullable: true, name: "follower_count" })
+  @Column({ name: "follower_count", default: 0 })
   followerCount!: number;
 
-  @Column({ nullable: true, name: "following_count" })
+  @Column({ name: "following_count", default: 0 })
   followingCount!: number;
 
-  @Column({ nullable: true, name: "volume_sum" })
+  @Column({ name: "volume_sum", default: 0 })
   volumeSum!: number;
 }

--- a/server/src/types/domain.d.ts
+++ b/server/src/types/domain.d.ts
@@ -10,7 +10,7 @@ export interface recordItem {
   deadlift: number;
   benchpress: number;
   SBD_sum: number;
-  date: string;
+  timeStamp: Date;
   userWeight: number;
 }
 


### PR DESCRIPTION
### 관련 이슈
클라이언트 측에서는 시간 조작의 위험성이 있어 이를 서버 시간 기준으로 전부 조정함

### 작업 사항
- [x] record 테이블 수정
- [x] exercise 테이블 수정

### 작업 요약
dayjs 객체를 사용해 서버 시간 기준으로 수정함

또한 날짜순 정렬 메서드도 timestamp 기준으로 정렬하게끔 수정함
