### PR TITLE
[BE] API - Alarm - SSE로 읽지 않은 알림 응답

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,13 @@ import StaticsPage from "@pages/StaticsPage";
 const queryClient = new QueryClient();
 
 const App = () => {
+  // //! sse 실행 방법
+  // const userId = 1;
+  // const eventSource = new EventSource(`http://localhost:8080/api/alarms/unread?userId=${userId}`);
+  // eventSource.onmessage = ({ data }) => {
+  //   console.log(`${userId}'s unread alarm: `, JSON.parse(data).unreadAlarmCount);
+  // };
+
   return (
     <BrowserRouter>
       <GlobalStyle />

--- a/server/src/converter/response.converter.ts
+++ b/server/src/converter/response.converter.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from "@nestjs/common";
 
 export const HttpResponse = {
-  success: (response: unknown) => {
+  success: (response: any) => {
     return {
       ok: true,
       statusCode: HttpStatus.OK,

--- a/server/src/domain/alarms/alarms.controller.ts
+++ b/server/src/domain/alarms/alarms.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get, Query } from "@nestjs/common";
-import { ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { Controller, Get, Param, Query, Sse } from "@nestjs/common";
+import { ApiOperation, ApiParam, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { Exception } from "@exception/exceptions";
 import { isValidUserId } from "@validation/validation";
 import { UsersService } from "@user/users.service";
 import { AlarmsService } from "./alarms.service";
+import { interval, map, Observable, switchMap } from "rxjs";
 
 @Controller("api/alarms")
 @ApiTags("ALARM API")
@@ -24,6 +25,26 @@ export class AlarmsController {
   async getUnreadAlarmCount(@Query("userId") userId: number) {
     if (!isValidUserId(userId)) throw new Exception().invalidUserIdError();
     return this.alarmService.countUnreadAlarm(userId);
+  }
+
+  // sse
+  @Sse("unread")
+  @ApiOperation({
+    summary: "해당 사용자가 읽지 않은 알림 수를 반환",
+  })
+  @ApiQuery({
+    name: "userId",
+    type: "number",
+  })
+  async sse(@Query("userId") userId: number): Promise<Observable<MessageEvent>> {
+    return interval(1000).pipe(
+      switchMap(async () => await this.alarmService.countUnreadAlarm(userId)),
+      map((prop) => {
+        return {
+          data: { unreadAlarmCount: prop.response.alarmCount },
+        } as MessageEvent;
+      }),
+    );
   }
 
   @Get("list")


### PR DESCRIPTION

### 관련 이슈
#328 

### 작업 사항
- [x] SSE로 1초마다 프론트에 응답 전송
- [x] 읽지 않은 알람 개수 응답

### 작업 요약
1초마다 프론트에 읽지 않은 알림 개수를 응답
DB 변화를 알아서 감지해서 응답됨을 확인

### 첨부
<img width="290" alt="스크린샷 2022-12-05 오후 3 00 33" src="https://user-images.githubusercontent.com/79911816/205563211-3aa17cc5-fcb9-4ba3-8e05-a8f78889c892.png">

