### PR TITLE
[BE] API 구현 - AUTH API - Guard 예외 처리

### DIFF
--- a/server/src/domain/users/users.controller.ts
+++ b/server/src/domain/users/users.controller.ts
@@ -3,6 +3,7 @@ import { ApiOperation, ApiTags, ApiQuery } from "@nestjs/swagger";
 import { isValidUserId } from "@validation/validation";
 import { Exception } from "@exception/exceptions";
 import { UsersService } from "./users.service";
+import { NoAuth } from "../../decorator/validate.decorator";
 
 @Controller("api/users")
 @ApiTags("USER API")
@@ -43,6 +44,7 @@ export class UsersController {
     return this.usersService.getRecommandUserList(userId);
   }
 
+  @NoAuth()
   @Get("checkName")
   @ApiOperation({
     summary: "유저 이름 중복 검사",


### PR DESCRIPTION
### 관련 이슈
- 회원가입 시(user id가 없는 상태) 유저 이름 중복 검사 API를 실행 시 Guard에 막히는 버그 수정

### 작업 사항
- [x] Guard 검증 예외 처리 추가


### 작업 요약
- 닉네임 중복 검사 시 Guard 검증 예외 처리 추가

