### PR TITLE
[BE] API - 무한 스크롤 위해 10개씩 응답

### DIFF
--- a/client/src/api/UserAPI.ts
+++ b/client/src/api/UserAPI.ts
@@ -18,7 +18,7 @@ const UserAPI = {
 
   getUser: async (userId: UserType.UserId) => {
     const path = `users/get`;
-    const response = await HttpClient.get(path, { id: userId });
+    const response = await HttpClient.get(path, { userId });
     const { user } = response.response as { user: UserType.UserInfo };
 
     return user;

--- a/server/src/domain/alarms/alarms.controller.ts
+++ b/server/src/domain/alarms/alarms.controller.ts
@@ -34,8 +34,12 @@ export class AlarmsController {
     name: "userId",
     type: "number",
   })
-  async getAlarmList(@Query("userId") userId: number) {
+  @ApiQuery({
+    name: "index",
+    type: "number",
+  })
+  async getAlarmList(@Query("userId") userId: number, @Query("index") index: number) {
     if (!isValidUserId(userId)) throw new Exception().invalidUserIdError();
-    return this.alarmService.getAlarmList(userId);
+    return this.alarmService.getAlarmList(userId, index);
   }
 }

--- a/server/src/domain/alarms/alarms.service.ts
+++ b/server/src/domain/alarms/alarms.service.ts
@@ -35,14 +35,13 @@ export class AlarmsService {
       .addSelect("user.name", "name")
       .addSelect("user.profile_image", "profile_image")
       .addSelect("alarm.check", "check")
-      .addSelect("alarm.sender_user_id", "sender_user_id")
       .addSelect("alarm.alarm_type", "alarm_type")
       .addSelect("alarm.time_stamp", "time_stamp")
       .innerJoin(User, "user", "user.user_id = alarm.sender_user_id")
       .where("alarm.user_id = :userId", { userId })
       .andWhere("alarm.id > :index", { index })
       .andWhere("DATE(alarm.time_stamp) >= DATE_ADD(NOW(), INTERVAL -1 MONTH)")
-      .take(10)
+      .limit(10)
       .getRawMany();
     await this.checkToReadAlarm(userId);
     return HttpResponse.success({

--- a/server/src/domain/alarms/alarms.service.ts
+++ b/server/src/domain/alarms/alarms.service.ts
@@ -27,10 +27,11 @@ export class AlarmsService {
     });
   }
 
-  async getAlarmList(userId: number) {
+  async getAlarmList(userId: number, index: number) {
     const alarmObject = await this.alarmRepository
       .createQueryBuilder("alarm")
-      .select("alarm.sender_user_id", "sender_user_id")
+      .select("alarm.id", "index")
+      .addSelect("alarm.sender_user_id", "sender_user_id")
       .addSelect("user.name", "name")
       .addSelect("user.profile_image", "profile_image")
       .addSelect("alarm.check", "check")
@@ -39,7 +40,9 @@ export class AlarmsService {
       .addSelect("alarm.time_stamp", "time_stamp")
       .innerJoin(User, "user", "user.user_id = alarm.sender_user_id")
       .where("alarm.user_id = :userId", { userId })
+      .andWhere("alarm.id > :index", { index })
       .andWhere("DATE(alarm.time_stamp) >= DATE_ADD(NOW(), INTERVAL -1 MONTH)")
+      .take(10)
       .getRawMany();
     await this.checkToReadAlarm(userId);
     return HttpResponse.success({


### PR DESCRIPTION
### 관련 이슈
#268 

### 작업 사항
- [x] 10개씩 끊어서 반환 구현

### 작업 요약
알람 페이지에서 무한 스크롤 요청시 index(pk)를 같이 보내 10개씩 끊어서 응답이 가도록 구현함

### 작업 사진

1번 사용자가 받은 알림은 총 5개
실험의 편의를 위해 2개씩 끊어서 캡쳐했습니다

아래와 같이 인덱스 같이 보내면 응답이 옵니다
(check는 잠시 무시)

![image](https://user-images.githubusercontent.com/79911816/205908821-430485bf-bb86-4ae2-a47d-26c7bd50924c.png)


