### PR TITLE
[BE] API 구현 - AUTH API - AuthGuard 버그 수정

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -35,13 +35,6 @@ import { typeormConfig } from "./config/typeorm.config";
     TypeOrmModule.forFeature([User]),
   ],
 
-  providers: [
-    JwtStrategy,
-    {
-      provide: APP_GUARD,
-      useClass: JwtAuthGuard,
-    },
-    { provide: APP_FILTER, useClass: HttpExceptionFilter },
-  ],
+  providers: [JwtStrategy, { provide: APP_FILTER, useClass: HttpExceptionFilter }],
 })
 export class AppModule {}

--- a/server/src/exception/exceptions.ts
+++ b/server/src/exception/exceptions.ts
@@ -56,14 +56,17 @@ export class Exception {
     const response = HttpResponse.failed(HttpStatus.FORBIDDEN, "Invalid Delete Error");
     return new ForbiddenException(response);
   }
-  
+
   routineNameDuplicate(): HttpException {
     const response = HttpResponse.failed(HttpStatus.FORBIDDEN, "Routine Name Duplicate");
     return new ForbiddenException(response);
   }
 
   guardError(): HttpException {
-    const response = HttpResponse.failed(HttpStatus.FORBIDDEN, "Auth Guard Error, Invalid User Id");
-    return new ForbiddenException(response);
+    const response = HttpResponse.failed(
+      HttpStatus.UNAUTHORIZED,
+      "Auth Guard Error, Invalid User Id",
+    );
+    return new UnauthorizedException(response);
   }
 }

--- a/server/src/guard/jwt.guard.ts
+++ b/server/src/guard/jwt.guard.ts
@@ -1,7 +1,6 @@
 import { ExecutionContext, Injectable } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { Reflector } from "@nestjs/core";
-import { Observable } from "rxjs";
 import { Exception } from "@exception/exceptions";
 
 @Injectable()
@@ -10,10 +9,19 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
     super();
   }
 
-  canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const noAuth = this.reflector.get<boolean>("no-auth", context.getHandler());
 
-    if (noAuth) return true;
+    if (noAuth) {
+      return true;
+    }
+
+    // call AuthGuard in order to ensure user is injected in request
+    const guardResult = await super.canActivate(context);
+
+    if (!guardResult) {
+      return false;
+    }
 
     const req = context.switchToHttp().getRequest();
 

--- a/server/src/guard/jwt.guard.ts
+++ b/server/src/guard/jwt.guard.ts
@@ -17,7 +17,8 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
     }
 
     // call AuthGuard in order to ensure user is injected in request
-    const guardResult = await super.canActivate(context);
+    // https://github.com/nestjs/passport/blob/master/lib/auth.guard.ts#L45
+    const guardResult = (await super.canActivate(context)) as boolean;
 
     if (!guardResult) {
       return false;

--- a/server/src/guard/jwt.strategy.ts
+++ b/server/src/guard/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { ExtractJwt, Strategy } from "passport-jwt";
+import { Strategy } from "passport-jwt";
 import { PassportStrategy } from "@nestjs/passport";
 import { Injectable } from "@nestjs/common";
 import { Request } from "express";

--- a/server/src/guard/jwt.strategy.ts
+++ b/server/src/guard/jwt.strategy.ts
@@ -1,23 +1,20 @@
 import { ExtractJwt, Strategy } from "passport-jwt";
 import { PassportStrategy } from "@nestjs/passport";
 import { Injectable } from "@nestjs/common";
-import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
 import { Request } from "express";
-import { User } from "@user/entities/user.entity";
 import { ACCESS_TOKEN_SECRETKEY } from "@env";
 import { JwtPayload } from "@type/jwt";
 import { Exception } from "@exception/exceptions";
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
-  constructor(@InjectRepository(User) private userRepository: Repository<User>) {
+  constructor() {
     const extractJwtFromCookie = (req: Request) => {
       let token = null;
       if (req && req.cookies) {
         token = req.cookies.access_token;
       }
-      return token || ExtractJwt.fromAuthHeaderAsBearerToken()(req);
+      return token;
     };
 
     super({

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -17,8 +17,7 @@ async function bootstrap() {
   // initDatabase();
 
   const app: NestExpressApplication = await NestFactory.create<NestExpressApplication>(AppModule);
-  const reflector = app.get(Reflector);
-  app.useGlobalGuards(new JwtAuthGuard(reflector)); // 전역 user id 검증 가드 적용
+
   app.useGlobalFilters(new HttpExceptionFilter()); // 전역 필터 적용
 
   app.use("/user_profiles", express.static(path.join(__dirname, "../user_profiles")));
@@ -32,6 +31,9 @@ async function bootstrap() {
   app.use(cookieParser());
 
   app.use(passport.initialize());
+
+  const reflector = app.get(Reflector);
+  app.useGlobalGuards(new JwtAuthGuard(reflector)); // 전역 user id 검증 가드 적용
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
### 관련 이슈
- AuthGuard에서 access_token의 userId를 못불러오던 버그

### 작업 사항
- [x] AuthGuard에서 access token의 userId를 못불러오던 버그 수정

### 작업 요약
- 알아본 결과 AuthGuard에서 비동기 관련 문제로 access token의 userId를 못불러오던 버그가 발생했다.
- 그래서 `getReuest`를 하기 전에 `const guardResult = await super.canActivate(context);`를 통해 AuthGuard를 먼저 불러 request안에 user를 inject하도록 했다.

### 참고 자료
[PassportJS, NestJS: canActivate method of AuthGuard('jwt')](https://stackoverflow.com/questions/65557077/passportjs-nestjs-canactivate-method-of-authguardjwt)

