### PR TITLE
[BE] SSE - EventEmitter로 알림 발생 이벤트 관리

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -15,8 +15,8 @@ import { MockModule } from "@mock/mock.module";
 import { JwtStrategy } from "@guard/jwt.strategy";
 import { JwtAuthGuard } from "@guard/jwt.guard";
 import { User } from "@user/entities/user.entity";
-import { UploadModule } from "./domain/uploads/upload.module";
 import { typeormConfig } from "./config/typeorm.config";
+import { EventModule } from "./domain/event/event.module";
 
 @Module({
   imports: [
@@ -32,6 +32,7 @@ import { typeormConfig } from "./config/typeorm.config";
     TypeOrmModule.forRoot(typeormConfig),
     PassportModule,
     TypeOrmModule.forFeature([User]),
+    EventModule,
   ],
 
   providers: [

--- a/server/src/domain/event/event.controller.ts
+++ b/server/src/domain/event/event.controller.ts
@@ -1,0 +1,14 @@
+import { Request } from "express";
+import { EventService } from "./event.service";
+import { Controller, Post, Req, Sse } from "@nestjs/common";
+
+@Controller("event")
+export class EventController {
+  constructor(private readonly eventsService: EventService) {}
+
+  @Sse("events")
+  events(@Req() req: Request) {
+    const userId = req.query.user_id;
+    return this.eventsService.registerChannel(Number(userId));
+  }
+}

--- a/server/src/domain/event/event.module.ts
+++ b/server/src/domain/event/event.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { EventController } from "./event.controller";
+import { EventService } from "./event.service";
+
+@Module({
+  controllers: [EventController],
+  providers: [EventService],
+})
+export class EventModule {}

--- a/server/src/domain/event/event.service.ts
+++ b/server/src/domain/event/event.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@nestjs/common";
+import { EventEmitter } from "events";
+import { fromEvent } from "rxjs";
+
+@Injectable()
+export class EventService {
+  private readonly emitter: EventEmitter;
+
+  constructor() {
+    //! NestJS의 module, provider는 싱글톤
+    this.emitter = new EventEmitter();
+  }
+
+  registerChannel(userId: number) {
+    return fromEvent(this.emitter, `${userId}ch`);
+  }
+}

--- a/server/src/domain/event/event.service.ts
+++ b/server/src/domain/event/event.service.ts
@@ -14,4 +14,10 @@ export class EventService {
   registerChannel(userId: number) {
     return fromEvent(this.emitter, `${userId}ch`);
   }
+
+  sendEvent(userIdList: Array<number>) {
+    userIdList.map((userId) => {
+      this.emitter.emit(`${userId}ch`, { message: true });
+    });
+  }
 }

--- a/server/src/domain/exercises/exercises.controller.ts
+++ b/server/src/domain/exercises/exercises.controller.ts
@@ -1,3 +1,5 @@
+import { EventService } from "./../event/event.service";
+import { FollowsService } from "@follow/follows.service";
 import { Exception } from "@exception/exceptions";
 import { ExercisesService } from "./exercises.service";
 import { Body, Controller, Get, Post, Query } from "@nestjs/common";
@@ -14,6 +16,8 @@ export class ExercisesController {
     private readonly exercisesService: ExercisesService,
     private readonly usersService: UsersService,
     private readonly alarmsService: AlarmsService,
+    private readonly followService: FollowsService,
+    private readonly eventService: EventService,
   ) {}
 
   @Get("everyDate")
@@ -67,6 +71,8 @@ export class ExercisesController {
   @ApiBody({ type: () => ExerciseDataDto })
   async submitExercise(@Body() exerciseData: ExerciseDataDto) {
     await this.alarmsService.sendExerciseAlarm(exerciseData.userId);
+    const followerUserIdList = await this.followService.getFollowerUserIdList(exerciseData.userId);
+    this.eventService.sendEvent(followerUserIdList);
     return this.exercisesService.submitSingleSBDRecord(exerciseData);
   }
 }

--- a/server/src/domain/exercises/exercises.module.ts
+++ b/server/src/domain/exercises/exercises.module.ts
@@ -1,3 +1,5 @@
+import { EventService } from "./../event/event.service";
+import { FollowsService } from "@follow/follows.service";
 import { Follow } from "@follow/entities/follow.entity";
 import { AlarmsService } from "@alarm/alarms.service";
 import { Alarm } from "@alarm/entities/alram.entity";
@@ -12,6 +14,6 @@ import { ExercisesService } from "./exercises.service";
 @Module({
   imports: [TypeOrmModule.forFeature([Exercise, User, Alarm, Follow])],
   controllers: [ExercisesController],
-  providers: [ExercisesService, UsersService, AlarmsService],
+  providers: [ExercisesService, UsersService, AlarmsService, FollowsService, EventService],
 })
 export class ExercisesModule {}

--- a/server/src/domain/follows/follows.controller.ts
+++ b/server/src/domain/follows/follows.controller.ts
@@ -1,3 +1,4 @@
+import { EventService } from "./../event/event.service";
 import { UsersService } from "@user/users.service";
 import { FollowsService } from "@follow/follows.service";
 import { Body, Controller, Get, Post, Query } from "@nestjs/common";
@@ -14,6 +15,7 @@ export class FollowsController {
     private readonly followService: FollowsService,
     private readonly usersService: UsersService,
     private readonly alarmsService: AlarmsService,
+    private readonly eventService: EventService,
   ) {}
 
   @Get("following")
@@ -51,6 +53,7 @@ export class FollowsController {
     const otherUserIdExist = await this.usersService.isExistUser(userIds.otherUserId);
     if (!myUserIdExist || !otherUserIdExist) throw new Exception().userNotFound();
     await this.alarmsService.sendFollowAlarm(userIds.myUserId, userIds.otherUserId);
+    this.eventService.sendEvent([userIds.otherUserId]);
     return this.followService.doFollow(userIds);
   }
 

--- a/server/src/domain/follows/follows.module.ts
+++ b/server/src/domain/follows/follows.module.ts
@@ -1,3 +1,4 @@
+import { EventService } from "./../event/event.service";
 import { AlarmsService } from "@alarm/alarms.service";
 import { Alarm } from "@alarm/entities/alram.entity";
 import { UsersService } from "@user/users.service";
@@ -11,6 +12,6 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 @Module({
   imports: [TypeOrmModule.forFeature([Follow, User, Alarm])],
   controllers: [FollowsController],
-  providers: [FollowsService, UsersService, AlarmsService],
+  providers: [FollowsService, UsersService, AlarmsService, EventService],
 })
 export class FollowsModule {}

--- a/server/src/domain/follows/follows.service.ts
+++ b/server/src/domain/follows/follows.service.ts
@@ -16,6 +16,16 @@ export class FollowsService {
     private userRepository: Repository<User>,
   ) {}
 
+  async getFollowerUserIdList(userId: number) {
+    const followerUserIdList = await this.followRepository
+      .createQueryBuilder("follow")
+      .select("follow.follower_id", "followerId")
+      .where("follow.followed_id = :userId", { userId })
+      .andWhere("follow.deleted = false")
+      .getRawMany();
+    return followerUserIdList.map((item) => item.followerId);
+  }
+
   async getFollowingUserList(userId: number) {
     const followingUserProfileList = await this.followRepository
       .createQueryBuilder("follow")

--- a/server/src/domain/users/users.controller.ts
+++ b/server/src/domain/users/users.controller.ts
@@ -13,7 +13,7 @@ import { ApiOperation, ApiTags, ApiQuery } from "@nestjs/swagger";
 import { isValidUserId } from "@validation/validation";
 import { Exception } from "@exception/exceptions";
 import { UsersService } from "./users.service";
-import { GetUserId } from "../../decorator/validate.decorator";
+// import { GetUserId } from "../../decorator/validate.decorator";
 import { UserProfileDto } from "./dto/user_profile.dto";
 import { FilesInterceptor } from "@nestjs/platform-express";
 import { multerOptions } from "./options/multer_options";


### PR DESCRIPTION

### 관련 이슈
#359 

### 작업 사항
- [x] eventEmitter 구현
- [x] 운동 완료시 emit 테스트
- [x] 팔로잉시 emit 테스트
- [ ] 프론트와 연계 테스트

### 작업 요약

각 사용자마다 1초 간격으로 DB에 접근하여 SSE로 읽지 않은 알림 받아오는 방식의 문제를 해결하기 위함

각 사용자는 초기 접속 시 딱 한 번 SSE를 위한 pipe를 열고,
자기 userId로 된 채널을 서버의 eventEmitter에 등록함

접속한 모든 사용자는 각자 하나의 채널을 가지고있는 셈

누군가 운동 완료시 그 사용자를 팔로잉 하는 사용자들에게 알림을 보내야하기 때문에,
운동 완료 API 호출 
-> 내부적으로 팔로워 리스트를 DB에서 가져옴
-> 순회하면서 각 사용자들의 채널에 emit
-> 각 사용자는 emit 사인을 받고 프론트에서 Get Unread Alarm API를 호출

이렇게 하면 1초마다 DB 접근이 아니라
전체 서비스에서 알림이 발생하는 경우에만 DB에 접근하도록 함
