### PR TITLE
[FE] 회원가입 페이지 - 예외처리

### DIFF
--- a/client/src/pages/JoinPage/index.tsx
+++ b/client/src/pages/JoinPage/index.tsx
@@ -116,7 +116,11 @@ const JoinPage = () => {
   }, [location, navigate, userInfo]);
 
   return (
-    <PageTemplate isRoot={false} onClickBackButton={step ? handleClickBackButton : undefined}>
+    <PageTemplate
+      ignoreException
+      isRoot={false}
+      onClickBackButton={step ? handleClickBackButton : undefined}
+    >
       <s.Wrapper>
         <s.Title>{joinProcess[step].title}</s.Title>
         <s.ContentWrapper>

--- a/client/src/pages/PageTemplate.tsx
+++ b/client/src/pages/PageTemplate.tsx
@@ -8,6 +8,7 @@ import Exception from "src/services/Exception";
 interface PageTemplateProps {
   isRoot: boolean;
   title?: string;
+  ignoreException?: boolean;
   topNavRightItem?: JSX.Element;
   onClickBackButton?: () => void;
   children: React.ReactNode;
@@ -16,12 +17,13 @@ interface PageTemplateProps {
 const PageTemplate = ({
   isRoot,
   title,
+  ignoreException,
   topNavRightItem,
   onClickBackButton,
   children,
 }: PageTemplateProps) => {
   useEffect(() => {
-    if (!authStorage.has()) {
+    if (!ignoreException && !authStorage.has()) {
       Exception.UserNotFound();
     }
   });


### PR DESCRIPTION
### 관련 이슈
> 실수로 회원가입 페이지에서도 로컬 스토리지의 user id를 확인하고 없으면 로그인 페이지로 이동하게 했다..

### 작업 사항
- 회원가입 페이시에서는 로컬 스토리지의 user id 확인 절차를 거치지 않도록 처리

### 작업 요약
>회원가입 페이시에서는 로컬 스토리지의 user id 확인 절차를 거치지 않도록 처리
