### PR TITLE
[FE] 코어 - React Query 캐싱 문제 해결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ const CalendarPage = lazy(() => import("@pages/CalendarPage"));
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      suspense: true,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       retry: false,

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,16 +20,17 @@ const StaticsPage = lazy(() => import("@pages/StaticsPage"));
 const SearchPage = lazy(() => import("@pages/SearchPage"));
 const CalendarPage = lazy(() => import("@pages/CalendarPage"));
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      retry: false,
+    },
+  },
+});
 
 const App = () => {
-  // //! sse 실행 방법
-  // const userId = 1;
-  // const eventSource = new EventSource(`http://localhost:8080/api/alarms/unread?userId=${userId}`);
-  // eventSource.onmessage = ({ data }) => {
-  //   console.log(`${userId}'s unread alarm: `, JSON.parse(data).unreadAlarmCount);
-  // };
-
   return (
     <BrowserRouter>
       <GlobalStyle />

--- a/client/src/api/ChallengeAPI.ts
+++ b/client/src/api/ChallengeAPI.ts
@@ -33,7 +33,7 @@ const ChallengeAPI = {
     const userId = authStorage.get();
     const path = "record/recent";
     const response = await HttpClient.get(path, { userId });
-
+    console.log(response);
     return response.response as ChallengeType.ChallengeTimestamp;
   },
 };

--- a/client/src/hooks/query/useAllExerciseDate.ts
+++ b/client/src/hooks/query/useAllExerciseDate.ts
@@ -4,9 +4,7 @@ import { QueryKey } from "@constants/enums";
 import { ExerciseDate } from "src/types/exercise";
 
 const useAllExerciseDate = () => {
-  const { data } = useQuery(QueryKey.EXERCISE_DATE_LIST, () => ExerciseAPI.getAllExerciseDate(), {
-    suspense: true,
-  });
+  const { data } = useQuery(QueryKey.EXERCISE_DATE_LIST, () => ExerciseAPI.getAllExerciseDate());
 
   return { exerciseDateList: [...(data as ExerciseDate)] };
 };

--- a/client/src/hooks/query/useBestChallengeScore.ts
+++ b/client/src/hooks/query/useBestChallengeScore.ts
@@ -4,12 +4,8 @@ import { QueryKey } from "@constants/enums";
 import { ChallengeDetail } from "src/types/challenge";
 
 const useBestChallengeScore = () => {
-  const { data } = useQuery(
-    QueryKey.BEST_CHALLENGE_SCORE,
-    () => ChallengeAPI.getBestChallengeScore(),
-    {
-      suspense: true,
-    },
+  const { data } = useQuery(QueryKey.BEST_CHALLENGE_SCORE, () =>
+    ChallengeAPI.getBestChallengeScore(),
   );
   const isEmpty = !Object.keys(data as ChallengeDetail).length;
 

--- a/client/src/hooks/query/useExerciseProfile.ts
+++ b/client/src/hooks/query/useExerciseProfile.ts
@@ -4,9 +4,7 @@ import { QueryKey } from "@constants/enums";
 import { ExerciseProfile } from "src/types/exercise";
 
 const useExerciseProfile = () => {
-  const { data } = useQuery(QueryKey.EXERCISE_PROFILE, () => ExerciseAPI.getExerciseProfile(), {
-    suspense: true,
-  });
+  const { data } = useQuery(QueryKey.EXERCISE_PROFILE, () => ExerciseAPI.getExerciseProfile());
 
   return { exerciseProfile: data as ExerciseProfile } as const;
 };

--- a/client/src/hooks/query/useRecentChallengeTime.ts
+++ b/client/src/hooks/query/useRecentChallengeTime.ts
@@ -7,7 +7,7 @@ const useRecentChallengeTime = () => {
   const { data } = useQuery(
     QueryKey.RECENT_CHALLENGE_TIME,
     () => ChallengeAPI.getRecentChallengeTime(),
-    { suspense: true },
+    { suspense: true, refetchOnWindowFocus: true, refetchOnMount: true, retry: true },
   );
 
   const { recentTimeStamp, nowTimeStamp } = data as ChallengeTimestamp;

--- a/client/src/hooks/query/useRecentChallengeTime.ts
+++ b/client/src/hooks/query/useRecentChallengeTime.ts
@@ -7,7 +7,7 @@ const useRecentChallengeTime = () => {
   const { data } = useQuery(
     QueryKey.RECENT_CHALLENGE_TIME,
     () => ChallengeAPI.getRecentChallengeTime(),
-    { suspense: true, refetchOnWindowFocus: true, refetchOnMount: true, retry: true },
+    { refetchOnWindowFocus: true, refetchOnMount: true, retry: true },
   );
 
   const { recentTimeStamp, nowTimeStamp } = data as ChallengeTimestamp;

--- a/client/src/hooks/query/useRoutineList.ts
+++ b/client/src/hooks/query/useRoutineList.ts
@@ -4,12 +4,8 @@ import ExerciseAPI from "@api/ExerciseAPI";
 import { UserId } from "src/types/user";
 
 const useRoutineList = (userId: UserId) => {
-  const { data } = useQuery(
-    [QueryKey.ROUTINE_LIST, userId],
-    () => ExerciseAPI.getRoutineList(userId),
-    {
-      suspense: true,
-    },
+  const { data } = useQuery([QueryKey.ROUTINE_LIST, userId], () =>
+    ExerciseAPI.getRoutineList(userId),
   );
 
   return { routineList: data } as const;

--- a/client/src/hooks/query/useUserInfo.ts
+++ b/client/src/hooks/query/useUserInfo.ts
@@ -4,9 +4,7 @@ import { QueryKey } from "@constants/enums";
 import { UserInfo, UserId } from "src/types/user";
 
 const useUserInfo = (userId: UserId) => {
-  const { data } = useQuery([QueryKey.USER_INFO, userId], () => UserAPI.getUser(userId), {
-    suspense: true,
-  });
+  const { data } = useQuery([QueryKey.USER_INFO, userId], () => UserAPI.getUser(userId));
 
   return { userInfo: data as UserInfo } as const;
 };


### PR DESCRIPTION
### 관련 이슈
페이지를 이동하거나, 탭을 잠시 닫았다가 다시 열 때마다 캐싱이 적용되지 않았다.

- 아래 코드와 같이 QueryClient의 defaultOptions을 적용하여 해결했다.

```ts
const queryClient = new QueryClient({
  defaultOptions: {
    queries: {
      suspense: true,
      refetchOnWindowFocus: false,
      refetchOnMount: false,
      retry: false,
    },
  },
});
```

### 작업 사항
- QueryClient default 캐싱 설정 적용
- 캐싱되면 안되는 useQuery에 캐싱 해제 옵션 추가
- QueryClient default Suspense 설정 적용

### 작업 요약
> 페이지를 이동할 때마다 캐싱이 되지 않고 서버에 API를 호출하는데, 이를 해결한다.

### 참고자료
> [[[react query] stale이란? (feat, 캐싱,use query,fetch, react query에 대해 알아보기)](https://2ham-s.tistory.com/407)](https://2ham-s.tistory.com/407)
