### PR TITLE
[BE] API - Alarm - SSE로 읽지 않은 알람 전송

### DIFF
--- a/client/src/pages/HomePage/index.tsx
+++ b/client/src/pages/HomePage/index.tsx
@@ -6,23 +6,23 @@ import CalendarHeatMap from "@components/CalendarHeatMap";
 import arrowRightSrc from "@public/icons/mark_arrow_right.svg";
 import { RoutePath } from "@constants/enums";
 import Calendar from "@components/Calendar";
-import useUserInfo from "@hooks/query/useUserInfo";
-import { authStorage } from "src/services/ClientStorage";
+// import useUserInfo from "@hooks/query/useUserInfo";
+// import { authStorage } from "src/services/ClientStorage";
 import * as s from "./style";
 
 const HomePage = () => {
   const navigate = useNavigate();
-  const { userInfo } = useUserInfo(authStorage.get());
-  useEffect(() => {
-    const userId = userInfo.id;
-    const subscription = new EventSource(
-      `http://localhost:8080/api/event/register?user_id=${userId}`,
-      { withCredentials: true },
-    );
-    subscription.onmessage = (message) => {
-      console.log(JSON.parse(message.data));
-    };
-  }, []);
+  // const { userInfo } = useUserInfo(authStorage.get());
+  // useEffect(() => {
+  //   const userId = userInfo.id;
+  //   const subscription = new EventSource(
+  //     `http://localhost:8080/api/event/register?user_id=${userId}`,
+  //     { withCredentials: true },
+  //   );
+  //   subscription.onmessage = (message) => {
+  //     console.log(JSON.parse(message.data));
+  //   };
+  // }, []);
 
   return (
     <PageTemplate isRoot>

--- a/client/src/pages/HomePage/index.tsx
+++ b/client/src/pages/HomePage/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import PageTemplate from "@pages/PageTemplate";
 import UserInfoSummary from "@components/UserInfoSummary";
@@ -6,10 +6,23 @@ import CalendarHeatMap from "@components/CalendarHeatMap";
 import arrowRightSrc from "@public/icons/mark_arrow_right.svg";
 import { RoutePath } from "@constants/enums";
 import Calendar from "@components/Calendar";
+import useUserInfo from "@hooks/query/useUserInfo";
+import { authStorage } from "src/services/ClientStorage";
 import * as s from "./style";
 
 const HomePage = () => {
   const navigate = useNavigate();
+  const { userInfo } = useUserInfo(authStorage.get());
+  useEffect(() => {
+    const userId = userInfo.id;
+    const subscription = new EventSource(
+      `http://localhost:8080/api/event/register?user_id=${userId}`,
+      { withCredentials: true },
+    );
+    subscription.onmessage = (message) => {
+      console.log(JSON.parse(message.data));
+    };
+  }, []);
 
   return (
     <PageTemplate isRoot>

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -16,6 +16,7 @@ import { JwtStrategy } from "@guard/jwt.strategy";
 import { JwtAuthGuard } from "@guard/jwt.guard";
 import { User } from "@user/entities/user.entity";
 import { typeormConfig } from "./config/typeorm.config";
+import { EventModule } from "./domain/event/event.module";
 
 @Module({
   imports: [
@@ -31,8 +32,11 @@ import { typeormConfig } from "./config/typeorm.config";
     TypeOrmModule.forRoot(typeormConfig),
     PassportModule,
     TypeOrmModule.forFeature([User]),
+    EventModule,
   ],
 
   providers: [JwtStrategy, { provide: APP_FILTER, useClass: HttpExceptionFilter }],
+
+  controllers: [],
 })
 export class AppModule {}

--- a/server/src/domain/event/event.controller.ts
+++ b/server/src/domain/event/event.controller.ts
@@ -1,0 +1,22 @@
+import { EventService } from "./event.service";
+import { Controller, Get, Post, Req, Sse } from "@nestjs/common";
+import { ApiTags } from "@nestjs/swagger";
+
+@Controller("api/event")
+@ApiTags("EVENT API")
+export class EventController {
+  constructor(private readonly eventService: EventService) {}
+
+  @Sse("register")
+  events(@Req() req: any) {
+    console.log("🧡🧡🧡🧡🧡🧡🧡🧡🧡🧡🧡🧡🧡 userId: ", req.query.user_id);
+    const userId = req.query.user_id;
+    return this.eventService.subscribe(userId);
+  }
+
+  @Post("test")
+  async emit() {
+    const userIdList = [5003, 5004];
+    this.eventService.emit(userIdList);
+  }
+}

--- a/server/src/domain/event/event.controller.ts
+++ b/server/src/domain/event/event.controller.ts
@@ -9,14 +9,8 @@ export class EventController {
 
   @Sse("register")
   events(@Req() req: any) {
-    console.log("🧡🧡🧡🧡🧡🧡🧡🧡🧡🧡🧡🧡🧡 userId: ", req.query.user_id);
+    console.log("🧡 userId: ", req.query.user_id);
     const userId = req.query.user_id;
     return this.eventService.subscribe(userId);
-  }
-
-  @Post("test")
-  async emit() {
-    const userIdList = [5003, 5004];
-    this.eventService.emit(userIdList);
   }
 }

--- a/server/src/domain/event/event.controller.ts
+++ b/server/src/domain/event/event.controller.ts
@@ -9,7 +9,6 @@ export class EventController {
 
   @Sse("register")
   events(@Req() req: any) {
-    console.log("🧡 userId: ", req.query.user_id);
     const userId = req.query.user_id;
     return this.eventService.subscribe(userId);
   }

--- a/server/src/domain/event/event.module.ts
+++ b/server/src/domain/event/event.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { EventController } from './event.controller';
+import { EventService } from './event.service';
+
+@Module({
+  controllers: [EventController],
+  providers: [EventService]
+})
+export class EventModule {}

--- a/server/src/domain/event/event.module.ts
+++ b/server/src/domain/event/event.module.ts
@@ -1,9 +1,10 @@
-import { Module } from '@nestjs/common';
-import { EventController } from './event.controller';
-import { EventService } from './event.service';
+import { Module } from "@nestjs/common";
+import { EventController } from "./event.controller";
+import { EventService } from "./event.service";
 
 @Module({
   controllers: [EventController],
-  providers: [EventService]
+  providers: [EventService],
+  exports: [EventService],
 })
 export class EventModule {}

--- a/server/src/domain/event/event.service.ts
+++ b/server/src/domain/event/event.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from "@nestjs/common";
+import EventEmitter from "events";
+import { fromEvent } from "rxjs";
+
+@Injectable()
+export class EventService {
+  readonly emitter: EventEmitter;
+
+  constructor() {
+    this.emitter = new EventEmitter();
+  }
+
+  subscribe(userId: number) {
+    return fromEvent(this.emitter, `${userId}ch`);
+  }
+
+  emit(userIdList: Array<number>) {
+    userIdList.map((userId) => {
+      console.log("🎯🎯 Send Event To ", userId);
+      this.emitter.emit(`${userId}ch`, { data: "true" });
+    });
+  }
+}

--- a/server/src/domain/event/event.service.ts
+++ b/server/src/domain/event/event.service.ts
@@ -17,7 +17,6 @@ export class EventService {
   emit(userIdList: Array<number>) {
     userIdList.map((userId) => {
       const isUserConnect = this.emitter.listeners(`${userId}ch`).length;
-      console.log("🎯🎯 Send Event To ", userId, ", connected: ", Boolean(isUserConnect));
       if (Boolean(isUserConnect)) {
         this.emitter.emit(`${userId}ch`, { data: "true" });
       }

--- a/server/src/domain/event/event.service.ts
+++ b/server/src/domain/event/event.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable, Scope } from "@nestjs/common";
 import EventEmitter from "events";
 import { fromEvent } from "rxjs";
 
@@ -16,8 +16,11 @@ export class EventService {
 
   emit(userIdList: Array<number>) {
     userIdList.map((userId) => {
-      console.log("🎯🎯 Send Event To ", userId);
-      this.emitter.emit(`${userId}ch`, { data: "true" });
+      const isUserConnect = this.emitter.listeners(`${userId}ch`).length;
+      console.log("🎯🎯 Send Event To ", userId, ", connected: ", Boolean(isUserConnect));
+      if (Boolean(isUserConnect)) {
+        this.emitter.emit(`${userId}ch`, { data: "true" });
+      }
     });
   }
 }

--- a/server/src/domain/exercises/exercises.controller.ts
+++ b/server/src/domain/exercises/exercises.controller.ts
@@ -1,11 +1,13 @@
+import { FollowsService } from "@follow/follows.service";
 import { Exception } from "@exception/exceptions";
 import { ExercisesService } from "./exercises.service";
-import { Body, Controller, Get, Post, Query } from "@nestjs/common";
+import { Body, Controller, Get, Inject, Post, Query } from "@nestjs/common";
 import { ApiBody, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { isValidMonth, isValidUserId } from "@validation/validation";
 import { ExerciseDataDto } from "./dto/exercise.dto";
 import { UsersService } from "@user/users.service";
 import { AlarmsService } from "@alarm/alarms.service";
+import { EventService } from "../event/event.service";
 
 @Controller("api/exercise")
 @ApiTags("EXERCISE API")
@@ -14,6 +16,8 @@ export class ExercisesController {
     private readonly exercisesService: ExercisesService,
     private readonly usersService: UsersService,
     private readonly alarmsService: AlarmsService,
+    private readonly followService: FollowsService,
+    private readonly eventService: EventService,
   ) {}
 
   @Get("everyDate")
@@ -67,6 +71,8 @@ export class ExercisesController {
   @ApiBody({ type: () => ExerciseDataDto })
   async submitExercise(@Body() exerciseData: ExerciseDataDto) {
     await this.alarmsService.sendExerciseAlarm(exerciseData.userId);
+    const followerUserIdList = await this.followService.getFollowerUserIdList(exerciseData.userId);
+    this.eventService.emit(followerUserIdList);
     return this.exercisesService.submitSingleSBDRecord(exerciseData);
   }
 }

--- a/server/src/domain/exercises/exercises.module.ts
+++ b/server/src/domain/exercises/exercises.module.ts
@@ -1,3 +1,5 @@
+import { EventModule } from "./../event/event.module";
+import { FollowsService } from "@follow/follows.service";
 import { Follow } from "@follow/entities/follow.entity";
 import { AlarmsService } from "@alarm/alarms.service";
 import { Alarm } from "@alarm/entities/alram.entity";
@@ -10,8 +12,8 @@ import { ExercisesController } from "./exercises.controller";
 import { ExercisesService } from "./exercises.service";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Exercise, User, Alarm, Follow])],
+  imports: [TypeOrmModule.forFeature([Exercise, User, Alarm, Follow]), EventModule],
   controllers: [ExercisesController],
-  providers: [ExercisesService, UsersService, AlarmsService],
+  providers: [ExercisesService, UsersService, AlarmsService, FollowsService],
 })
 export class ExercisesModule {}

--- a/server/src/domain/follows/follows.controller.ts
+++ b/server/src/domain/follows/follows.controller.ts
@@ -6,6 +6,7 @@ import { isValidUserId } from "@validation/validation";
 import { Exception } from "@exception/exceptions";
 import { FollowUserIdDto } from "./dto/follow.dto";
 import { AlarmsService } from "@alarm/alarms.service";
+import { EventService } from "../event/event.service";
 
 @Controller("api/follow")
 @ApiTags("FOLLOW API")
@@ -14,6 +15,7 @@ export class FollowsController {
     private readonly followService: FollowsService,
     private readonly usersService: UsersService,
     private readonly alarmsService: AlarmsService,
+    private readonly eventService: EventService,
   ) {}
 
   @Get("following")
@@ -51,6 +53,7 @@ export class FollowsController {
     const otherUserIdExist = await this.usersService.isExistUser(userIds.otherUserId);
     if (!myUserIdExist || !otherUserIdExist) throw new Exception().userNotFound();
     await this.alarmsService.sendFollowAlarm(userIds.myUserId, userIds.otherUserId);
+    this.eventService.emit([userIds.otherUserId]);
     return this.followService.doFollow(userIds);
   }
 

--- a/server/src/domain/follows/follows.module.ts
+++ b/server/src/domain/follows/follows.module.ts
@@ -1,3 +1,4 @@
+import { EventModule } from "./../event/event.module";
 import { AlarmsService } from "@alarm/alarms.service";
 import { Alarm } from "@alarm/entities/alram.entity";
 import { UsersService } from "@user/users.service";
@@ -9,7 +10,7 @@ import { FollowsService } from "./follows.service";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Follow, User, Alarm])],
+  imports: [TypeOrmModule.forFeature([Follow, User, Alarm]), EventModule],
   controllers: [FollowsController],
   providers: [FollowsService, UsersService, AlarmsService],
 })

--- a/server/src/domain/follows/follows.service.ts
+++ b/server/src/domain/follows/follows.service.ts
@@ -24,6 +24,15 @@ export class FollowsService {
     return this.followRepository.count({ where: { followerId: userId } });
   }
 
+  async getFollowerUserIdList(userId: number) {
+    const followerUserIdList = await this.followRepository
+      .createQueryBuilder("follow")
+      .select("follow.follower_id", "follower_id")
+      .where("follow.followed_id = :userId", { userId })
+      .getRawMany();
+    return followerUserIdList.map((item) => item.follower_id);
+  }
+
   async getFollowingUserList(userId: number) {
     const followingUserProfileList = await this.followRepository
       .createQueryBuilder("follow")

--- a/server/src/guard/jwt.guard.ts
+++ b/server/src/guard/jwt.guard.ts
@@ -5,24 +5,24 @@ import { Exception } from "@exception/exceptions";
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard("jwt") {
-  // constructor(private readonly reflector: Reflector) {
-  //   super();
-  // }
-  // async canActivate(context: ExecutionContext): Promise<boolean> {
-  //   const noAuth = this.reflector.get<boolean>("no-auth", context.getHandler());
-  //   if (noAuth) {
-  //     return true;
-  //   }
-  //   // call AuthGuard in order to ensure user is injected in request
-  //   // https://github.com/nestjs/passport/blob/master/lib/auth.guard.ts#L45
-  //   const guardResult = (await super.canActivate(context)) as boolean;
-  //   if (!guardResult) {
-  //     return false;
-  //   }
-  //   const req = context.switchToHttp().getRequest();
-  //   if (Number(req.headers.user_id) !== req.user) {
-  //     throw new Exception().guardError();
-  //   }
-  //   return true;
-  // }
+  constructor(private readonly reflector: Reflector) {
+    super();
+  }
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const noAuth = this.reflector.get<boolean>("no-auth", context.getHandler());
+    if (noAuth) {
+      return true;
+    }
+    // call AuthGuard in order to ensure user is injected in request
+    // https://github.com/nestjs/passport/blob/master/lib/auth.guard.ts#L45
+    const guardResult = (await super.canActivate(context)) as boolean;
+    if (!guardResult) {
+      return false;
+    }
+    const req = context.switchToHttp().getRequest();
+    if (Number(req.headers.user_id) !== req.user) {
+      throw new Exception().guardError();
+    }
+    return true;
+  }
 }

--- a/server/src/guard/jwt.guard.ts
+++ b/server/src/guard/jwt.guard.ts
@@ -5,31 +5,24 @@ import { Exception } from "@exception/exceptions";
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard("jwt") {
-  constructor(private readonly reflector: Reflector) {
-    super();
-  }
-
-  async canActivate(context: ExecutionContext): Promise<boolean> {
-    const noAuth = this.reflector.get<boolean>("no-auth", context.getHandler());
-
-    if (noAuth) {
-      return true;
-    }
-
-    // call AuthGuard in order to ensure user is injected in request
-    // https://github.com/nestjs/passport/blob/master/lib/auth.guard.ts#L45
-    const guardResult = (await super.canActivate(context)) as boolean;
-
-    if (!guardResult) {
-      return false;
-    }
-
-    const req = context.switchToHttp().getRequest();
-
-    if (Number(req.headers.user_id) !== req.user) {
-      throw new Exception().guardError();
-    }
-
-    return true;
-  }
+  // constructor(private readonly reflector: Reflector) {
+  //   super();
+  // }
+  // async canActivate(context: ExecutionContext): Promise<boolean> {
+  //   const noAuth = this.reflector.get<boolean>("no-auth", context.getHandler());
+  //   if (noAuth) {
+  //     return true;
+  //   }
+  //   // call AuthGuard in order to ensure user is injected in request
+  //   // https://github.com/nestjs/passport/blob/master/lib/auth.guard.ts#L45
+  //   const guardResult = (await super.canActivate(context)) as boolean;
+  //   if (!guardResult) {
+  //     return false;
+  //   }
+  //   const req = context.switchToHttp().getRequest();
+  //   if (Number(req.headers.user_id) !== req.user) {
+  //     throw new Exception().guardError();
+  //   }
+  //   return true;
+  // }
 }


### PR DESCRIPTION

### 관련 이슈
#328 

### 작업 사항
- [x] 프론트에서 SSE + EventEmitter 등록
- [x] 채널 등록 확인
- [x] 테스트 메시지 전송 테스트
- [x] EventService 객체 싱글톤으로 선언 후 DI
- [x] 운동 완료 API 호출시 알림 테스트 - in 프론트 콘솔
- [x] 팔로우 API 호출시 알림 테스트 - in 프론트 콘솔
- [x] 필요 코드 주석 해제 및 클라이언트 호출 코드 주석 처리

### 작업 요약
각 사용자는 초기 접속 시 각 userId로 된 채널을 EventEmitter에 등록함
누군가 운동을 완료하거나 팔로우하면 연관 관계가 있는 사용자에게 SSE 발신하여
클라이언트에서 알림 갱신 신호를 받아 Get Unread Alarm API를 호출하여
실시간으로 알림을 갱신하도록 구현함

### 참고자료
[SSE core](https://stackoverflow.com/questions/67202527/can-we-use-server-sent-events-in-nestjs-without-using-interval)
[NestJS DI](https://medium.com/crocusenergy/nestjs-modules-%EA%B0%9C%EB%85%90-%EB%B0%8F-%EC%8B%A4%EC%8A%B5-758b1328e9e7)