### PR TITLE
[BE] No AuthGuard 스크립트 추가

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "start:noguard": "nest start --watch -- noguard",
+    "start:guard": "nest start --watch -- guard",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/server/package.json
+++ b/server/package.json
@@ -11,15 +11,15 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "start:guard": "nest start --watch -- guard",
+    "start:noguard": "nest start --watch -- noguard",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "test:cov": "jest --coverage -- noguard",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json -- noguard"
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
+    "start:noguard": "nest start --watch -- noguard",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -32,9 +32,8 @@ async function bootstrap() {
 
   app.use(passport.initialize());
 
-  const reflector = app.get(Reflector);
-
   if (!(process.argv[2] === "noguard")) {
+    const reflector = app.get(Reflector);
     app.useGlobalGuards(new JwtAuthGuard(reflector)); // 전역 user id 검증 가드 적용
   }
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -34,7 +34,7 @@ async function bootstrap() {
 
   const reflector = app.get(Reflector);
 
-  if (!(process.argv[2] === "noguard")) {
+  if (process.argv[2] === "guard") {
     app.useGlobalGuards(new JwtAuthGuard(reflector)); // 전역 user id 검증 가드 적용
   }
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -33,7 +33,10 @@ async function bootstrap() {
   app.use(passport.initialize());
 
   const reflector = app.get(Reflector);
-  app.useGlobalGuards(new JwtAuthGuard(reflector)); // 전역 user id 검증 가드 적용
+
+  if (!(process.argv[2] === "noguard")) {
+    app.useGlobalGuards(new JwtAuthGuard(reflector)); // 전역 user id 검증 가드 적용
+  }
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -34,7 +34,7 @@ async function bootstrap() {
 
   const reflector = app.get(Reflector);
 
-  if (process.argv[2] === "guard") {
+  if (!(process.argv[2] === "noguard")) {
     app.useGlobalGuards(new JwtAuthGuard(reflector)); // 전역 user id 검증 가드 적용
   }
 


### PR DESCRIPTION
### 관련 이슈
- AuthGuard로 인해 개발(디버깅)에 지속적으로 지장이 생겨 가드를 사용하지 않고 실행 가능한 스크립트 추가

### 작업 사항
- [x] No AuthGuard 스크립트 추가

### 작업 요약
- `npm run start:noguard` 를 통해 가드 비활성화한채로 실행 가능 이외에는 `start:dev`와 동일
