### PR TITLE
[BE] DB - Trigger 적용으로 인해 Get User Info API에 팔로워 가져오기 삭제

### DIFF
--- a/server/src/domain/users/users.controller.ts
+++ b/server/src/domain/users/users.controller.ts
@@ -22,9 +22,7 @@ export class UsersController {
     type: "number",
   })
   async getUserInfo(@Query("userId") userId: number) {
-    const followerCount = await this.followService.getFollowerCount(userId);
-    const followingCount = await this.followService.getFollowingCount(userId);
-    return this.usersService.getUserInfo(userId, followerCount, followingCount);
+    return this.usersService.getUserInfo(userId);
   }
 
   @Get("search")

--- a/server/src/domain/users/users.service.ts
+++ b/server/src/domain/users/users.service.ts
@@ -27,15 +27,13 @@ export class UsersService {
     return !!userExist;
   }
 
-  async getUserInfo(userId: number, followerCount: number, followingCount: number) {
+  async getUserInfo(userId: number) {
     const userObject = await this.userRepository
       .createQueryBuilder("user")
       .where("user.id = :userId", { userId })
       .getOne();
     const user = {
       ...userObject,
-      followerCount,
-      followingCount,
     };
     if (!user) {
       throw new Exception().userNotFound();


### PR DESCRIPTION
### 관련 이슈
Get User Info API에서 follower, following 정보를 가져오기 위해 follow 테이블에 2번이나 접근해야했음
Do Follow, Cancel Follow API 요청시 TRIGGER를 발동시켜, 
자동으로 user 테이블에 follower_count, following_count 컬럼이 UPDATE 되도록 변경함

### 작업 사항
- [x] TRIGGER 3개 설정
- [x] 기존 코드 삭제

### 작업 요약
TRIGGER 설정으로 인해 이를 대체
성능 향상 기대


### 첨부
트리거 파일
<img width="953" alt="스크린샷 2022-12-15 오후 6 59 43" src="https://user-images.githubusercontent.com/79911816/207829941-82cda480-3f4d-474d-ab00-b5a55f6a94f1.png">
<img width="433" alt="스크린샷 2022-12-15 오후 7 00 03" src="https://user-images.githubusercontent.com/79911816/207830022-b67d5422-49bf-46ae-bdda-f227edb1358e.png">

