### PR TITLE
[FE] favicon 403 에러 해결

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -24,6 +24,7 @@ const loadPlugin = () => {
     new CopyWebpackPlugin({
       patterns: [
         { from: "./public/appImages", to: "appImages" },
+        { from: "./public/favicon.ico", to: "." },
         { from: "./public/manifest.json", to: "." },
         { from: "./public/pwaServiceWorker.js", to: "." },
       ],


### PR DESCRIPTION
### 작업 사항
- [x] favicon 403 에러 해결

### 작업 요약
> 배포 환경에서의favicon.ico 파일의 403 에러를 해결한다.

