### PR TITLE
[FE] 서비스 워커 에러 해결

### DIFF
--- a/client/public/pwaServiceWorker.js
+++ b/client/public/pwaServiceWorker.js
@@ -11,7 +11,7 @@ const APP_SHELL = [
   "/appImages/screenshot-profile.webp",
   "/appImages/screenshot-search.webp",
   "/appImages/screenshot-statistics.webp",
-  "favicon.ico",
+  "/favicon.ico",
   "/manifest.json",
   "/index.html",
 ];


### PR DESCRIPTION
### 관련 이슈

<img width="627" alt="image" src="https://user-images.githubusercontent.com/33220404/208049147-02583265-be7b-40c0-81f3-e5a946bf2d86.png">

favicon 403 forbbiden로 인한 서비스 워커 에러가 발생한 것으로 파악했다.

### 작업 사항
- [x] 서비스 워커 에러 해결

### 작업 요약
> 배포 환경에서의 서비스 워커의 프로미스 에러를 해결한다.
